### PR TITLE
test: add WebPanel frontend test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ This repository uses a hard-gated change workflow for local work and PRs.
 - Any change to user-facing UI text must update both [`web/src/i18n/locales/zh-CN.json`](web/src/i18n/locales/zh-CN.json) and [`web/src/i18n/locales/en.json`](web/src/i18n/locales/en.json) in the same PR.
 - Do not merge a change that ships one locale ahead of the other.
 
-`scripts/check.sh` is the single local entry point. It runs the WebPanel Go tests, the frontend production build, and the key-path regression smoke test in [`tests/test_web_smoke.py`](tests/test_web_smoke.py).
+`scripts/check.sh` is the single local entry point. It runs the WebPanel Go tests, the frontend Vitest suite, the frontend production build, and the key-path regression smoke test in [`tests/test_web_smoke.py`](tests/test_web_smoke.py).
 
 Release packaging workflows in [`.github/workflows/release.yml`](.github/workflows/release.yml) and [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml) are reserved for version tags, published releases, and manual dispatch, so normal PRs stay on the fast validation path.
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -32,6 +32,12 @@ if [[ ! -d "$ROOT_DIR/web/node_modules" ]]; then
   )
 fi
 
+log "Web tests"
+(
+  cd web
+  npm run test
+)
+
 log "Web build"
 (
   cd web

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,10 +21,53 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@vitejs/plugin-vue": "^5.1.0",
+        "jsdom": "^29.0.1",
         "typescript": "^5.6.0",
         "vite": "^6.0.0",
+        "vitest": "^4.1.2",
         "vue-tsc": "^2.1.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/css-color/-/css-color-5.1.4.tgz",
+      "integrity": "sha512-503MoTEmPSyEJ7zQ+5vlkwPtkyxDhbDwR9ajk/jpPGrCLiUFHzgEG4iViUPKdGlZPRT1mWSPSbDL2qkOoLU4vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmmirror.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -72,6 +115,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmmirror.com/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@css-render/plugin-bem": {
       "version": "0.15.14",
       "resolved": "https://registry.npmmirror.com/@css-render/plugin-bem/-/plugin-bem-0.15.14.tgz",
@@ -88,6 +144,146 @@
       "license": "MIT",
       "peerDependencies": {
         "vue": "^3.0.11"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -538,6 +734,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmmirror.com/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@intlify/core-base": {
       "version": "10.0.7",
       "resolved": "https://registry.npmmirror.com/@intlify/core-base/-/core-base-10.0.7.tgz",
@@ -944,6 +1158,31 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.8.tgz",
@@ -988,6 +1227,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -1168,6 +1530,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-validator": {
       "version": "4.2.5",
       "resolved": "https://registry.npmmirror.com/async-validator/-/async-validator-4.2.5.tgz",
@@ -1198,6 +1570,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1221,6 +1603,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1232,6 +1624,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/css-render": {
       "version": "0.15.14",
@@ -1249,11 +1648,39 @@
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmmirror.com/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -1278,6 +1705,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmmirror.com/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1343,6 +1777,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1424,6 +1865,16 @@
       "resolved": "https://registry.npmmirror.com/evtd/-/evtd-0.2.4.tgz",
       "integrity": "sha512-qaeGN5bx63s/AXgQo8gj6fBkxge+OoLddLniox5qtLAEY5HSnuSlISXVPxnSae1dWblvTh4/HoMIB+mbMsvZzw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1610,6 +2061,67 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmmirror.com/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
@@ -1621,6 +2133,16 @@
       "resolved": "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.17.23.tgz",
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1639,6 +2161,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmmirror.com/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -1734,10 +2263,54 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1816,6 +2389,16 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qrcode.vue": {
       "version": "3.8.0",
       "resolved": "https://registry.npmmirror.com/qrcode.vue/-/qrcode.vue-3.8.0.tgz",
@@ -1823,6 +2406,16 @@
       "license": "MIT",
       "peerDependencies": {
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -1870,11 +2463,31 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/seemly": {
       "version": "0.3.10",
       "resolved": "https://registry.npmmirror.com/seemly/-/seemly-0.3.10.tgz",
       "integrity": "sha512-2+SMxtG1PcsL0uyhkumlOU6Qo9TAQ/WyH7tthnPIOQB05/12jz9naq6GZ6iZ6ApVsO3rr2gsnTf3++OV63kE1Q==",
       "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1883,6 +2496,44 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1900,6 +2551,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmmirror.com/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmmirror.com/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/treemate": {
@@ -1926,6 +2633,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -2019,6 +2736,88 @@
         },
         "yaml": {
           "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -2202,6 +3001,88 @@
       "peerDependencies": {
         "vue": "^3.0.11"
       }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zrender": {
       "version": "5.6.1",

--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview"
   },
@@ -22,8 +24,10 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@vitejs/plugin-vue": "^5.1.0",
+    "jsdom": "^29.0.1",
     "typescript": "^5.6.0",
     "vite": "^6.0.0",
+    "vitest": "^4.1.2",
     "vue-tsc": "^2.1.0"
   }
 }

--- a/web/src/i18n/locale-parity.test.ts
+++ b/web/src/i18n/locale-parity.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import en from '@/i18n/locales/en.json'
+import zhCn from '@/i18n/locales/zh-CN.json'
+
+function flattenKeys(input: unknown, prefix = ''): string[] {
+  if (input == null || typeof input !== 'object' || Array.isArray(input)) {
+    return prefix ? [prefix] : []
+  }
+
+  return Object.entries(input as Record<string, unknown>)
+    .flatMap(([key, value]) => flattenKeys(value, prefix ? `${prefix}.${key}` : key))
+}
+
+describe('locale parity', () => {
+  it('keeps zh-CN and en locale key paths aligned', () => {
+    const zhKeys = flattenKeys(zhCn).sort()
+    const enKeys = flattenKeys(en).sort()
+
+    expect(zhKeys).toEqual(enKeys)
+  })
+})

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { copyToClipboard, formatBytes, formatSpeed, formatTimestamp, formatUptime, generateUUID } from '@/utils/format'
+
+describe('format utilities', () => {
+  it('formats bytes and speeds with readable units', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatSpeed(1048576)).toBe('1 MB/s')
+  })
+
+  it('formats uptime into compact parts', () => {
+    expect(formatUptime(59)).toBe('59s')
+    expect(formatUptime(3661)).toBe('1h 1m')
+    expect(formatUptime(90061)).toBe('1d 1h 1m')
+  })
+
+  it('formats timestamps and generates UUID-like identifiers', () => {
+    expect(formatTimestamp(0)).toBe('-')
+    expect(formatTimestamp(1710000000)).not.toBe('-')
+    expect(generateUUID()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  it('delegates clipboard copies to the browser API', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, {
+      clipboard: { writeText }
+    })
+
+    await copyToClipboard('hello')
+
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+})

--- a/web/src/utils/nodePool.test.ts
+++ b/web/src/utils/nodePool.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NodeRecord } from '@/api/types'
+import { failRateValue, normalizeListInput, sortPoolNodes, sortRemovedNodes } from '@/utils/nodePool'
+
+function makeNode(overrides: Partial<NodeRecord>): NodeRecord {
+  return {
+    id: 'node',
+    uri: 'vless://node',
+    remark: 'node',
+    protocol: 'vless',
+    address: 'example.com',
+    port: 443,
+    outboundTag: '',
+    status: 'candidate',
+    statusReason: 'subscription_node_discovered',
+    subscriptionId: 'sub-1',
+    addedAt: '2026-01-01T00:00:00Z',
+    promotedAt: undefined,
+    statusUpdatedAt: '2026-01-01T00:00:00Z',
+    lastEventAt: '2026-01-01T00:00:00Z',
+    totalPings: 0,
+    failedPings: 0,
+    avgDelayMs: 0,
+    consecutiveFails: 0,
+    lastCheckedAt: '2026-01-01T00:00:00Z',
+    cleanliness: 'unknown',
+    bandwidthTier: '',
+    ...overrides
+  }
+}
+
+describe('node pool utilities', () => {
+  it('normalizes newline/comma separated lists and removes duplicates', () => {
+    expect(normalizeListInput(' 1.1.1.1 \n8.8.8.8,1.1.1.1\n\nhttps://dns.google/dns-query '))
+      .toEqual(['1.1.1.1', '8.8.8.8', 'https://dns.google/dns-query'])
+  })
+
+  it('sorts pool nodes by quality and explicit metric modes', () => {
+    const highQuality = makeNode({
+      id: 'high',
+      totalPings: 20,
+      failedPings: 0,
+      avgDelayMs: 120,
+      lastCheckedAt: '2026-01-03T00:00:00Z'
+    })
+    const mediumQuality = makeNode({
+      id: 'medium',
+      totalPings: 20,
+      failedPings: 2,
+      avgDelayMs: 200,
+      lastCheckedAt: '2026-01-02T00:00:00Z'
+    })
+    const unknownQuality = makeNode({
+      id: 'unknown',
+      totalPings: 0,
+      failedPings: 0,
+      avgDelayMs: 0,
+      lastCheckedAt: '2026-01-04T00:00:00Z'
+    })
+
+    expect(sortPoolNodes([mediumQuality, unknownQuality, highQuality], 'quality').map((node) => node.id))
+      .toEqual(['high', 'medium', 'unknown'])
+    expect(sortPoolNodes([mediumQuality, highQuality], 'last_checked_desc').map((node) => node.id))
+      .toEqual(['high', 'medium'])
+    expect(sortPoolNodes([mediumQuality, highQuality], 'avg_delay_desc').map((node) => node.id))
+      .toEqual(['medium', 'high'])
+  })
+
+  it('sorts removed nodes by removal time and metrics', () => {
+    const newest = makeNode({
+      id: 'newest',
+      status: 'removed',
+      statusUpdatedAt: '2026-01-04T00:00:00Z',
+      totalPings: 10,
+      failedPings: 10,
+      avgDelayMs: 900
+    })
+    const oldest = makeNode({
+      id: 'oldest',
+      status: 'removed',
+      statusUpdatedAt: '2026-01-01T00:00:00Z',
+      totalPings: 10,
+      failedPings: 1,
+      avgDelayMs: 100
+    })
+
+    expect(sortRemovedNodes([oldest, newest], 'removed_desc').map((node) => node.id)).toEqual(['newest', 'oldest'])
+    expect(sortRemovedNodes([oldest, newest], 'fail_rate_asc').map((node) => node.id)).toEqual(['oldest', 'newest'])
+  })
+
+  it('returns infinity for nodes without probe samples', () => {
+    expect(failRateValue(makeNode({ totalPings: 0, failedPings: 0 }))).toBe(Number.POSITIVE_INFINITY)
+  })
+})

--- a/web/src/utils/nodePool.ts
+++ b/web/src/utils/nodePool.ts
@@ -1,0 +1,131 @@
+import type { NodeRecord } from '@/api/types'
+
+export type PoolSortMode =
+  | 'quality'
+  | 'last_checked_desc'
+  | 'last_checked_asc'
+  | 'fail_rate_asc'
+  | 'fail_rate_desc'
+  | 'avg_delay_asc'
+  | 'avg_delay_desc'
+
+export type RemovedSortMode =
+  | 'removed_desc'
+  | 'removed_asc'
+  | 'fail_rate_asc'
+  | 'fail_rate_desc'
+  | 'avg_delay_asc'
+  | 'avg_delay_desc'
+
+export function failRateValue(node: Pick<NodeRecord, 'totalPings' | 'failedPings'>): number {
+  if (!node.totalPings) return Number.POSITIVE_INFINITY
+  return node.failedPings / node.totalPings
+}
+
+function delayValue(node: Pick<NodeRecord, 'avgDelayMs'>): number {
+  return node.avgDelayMs > 0 ? node.avgDelayMs : Number.POSITIVE_INFINITY
+}
+
+function checkedAtValue(node: Pick<NodeRecord, 'lastCheckedAt' | 'statusUpdatedAt' | 'addedAt'>): number {
+  const value = node.lastCheckedAt || node.statusUpdatedAt || node.addedAt
+  const timestamp = value ? new Date(value).getTime() : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function removedAtValue(node: Pick<NodeRecord, 'statusUpdatedAt' | 'lastEventAt' | 'addedAt'>): number {
+  const value = node.statusUpdatedAt || node.lastEventAt || node.addedAt
+  const timestamp = value ? new Date(value).getTime() : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+function compareNodesByQuality(a: NodeRecord, b: NodeRecord): number {
+  const failRateDiff = failRateValue(a) - failRateValue(b)
+  if (failRateDiff !== 0) return failRateDiff
+
+  const delayDiff = delayValue(a) - delayValue(b)
+  if (delayDiff !== 0) return delayDiff
+
+  if (a.consecutiveFails !== b.consecutiveFails) {
+    return a.consecutiveFails - b.consecutiveFails
+  }
+
+  if (a.totalPings !== b.totalPings) {
+    return b.totalPings - a.totalPings
+  }
+
+  return checkedAtValue(b) - checkedAtValue(a)
+}
+
+function compareNullableMetric(aValue: number | null, bValue: number | null, direction: 'asc' | 'desc'): number {
+  if (aValue == null && bValue == null) return 0
+  if (aValue == null) return 1
+  if (bValue == null) return -1
+  return direction === 'asc' ? aValue - bValue : bValue - aValue
+}
+
+export function sortPoolNodes(entries: NodeRecord[], mode: PoolSortMode): NodeRecord[] {
+  return [...entries].sort((a, b) => {
+    switch (mode) {
+      case 'last_checked_desc':
+        return checkedAtValue(b) - checkedAtValue(a)
+      case 'last_checked_asc':
+        return checkedAtValue(a) - checkedAtValue(b)
+      case 'fail_rate_asc': {
+        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'asc')
+        return diff !== 0 ? diff : compareNodesByQuality(a, b)
+      }
+      case 'fail_rate_desc': {
+        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'desc')
+        return diff !== 0 ? diff : compareNodesByQuality(a, b)
+      }
+      case 'avg_delay_asc': {
+        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'asc')
+        return diff !== 0 ? diff : compareNodesByQuality(a, b)
+      }
+      case 'avg_delay_desc': {
+        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'desc')
+        return diff !== 0 ? diff : compareNodesByQuality(a, b)
+      }
+      default:
+        return compareNodesByQuality(a, b)
+    }
+  })
+}
+
+export function sortRemovedNodes(entries: NodeRecord[], mode: RemovedSortMode): NodeRecord[] {
+  return [...entries].sort((a, b) => {
+    switch (mode) {
+      case 'removed_asc':
+        return removedAtValue(a) - removedAtValue(b)
+      case 'fail_rate_asc': {
+        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'asc')
+        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
+      }
+      case 'fail_rate_desc': {
+        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'desc')
+        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
+      }
+      case 'avg_delay_asc': {
+        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'asc')
+        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
+      }
+      case 'avg_delay_desc': {
+        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'desc')
+        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
+      }
+      default:
+        return removedAtValue(b) - removedAtValue(a)
+    }
+  })
+}
+
+export function normalizeListInput(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .split(/[\n,]/)
+        .map((item) => item.trim())
+        .filter(Boolean)
+    )
+  )
+}

--- a/web/src/views/NodePool.vue
+++ b/web/src/views/NodePool.vue
@@ -671,11 +671,16 @@ import type {
   TunStatusResponse,
   ValidationConfig
 } from '@/api/types'
+import {
+  normalizeListInput,
+  sortPoolNodes,
+  sortRemovedNodes,
+  type PoolSortMode,
+  type RemovedSortMode
+} from '@/utils/nodePool'
 
 const { t, te } = useI18n()
 const message = useMessage()
-
-type PoolSortMode = 'quality' | 'last_checked_desc' | 'last_checked_asc' | 'fail_rate_asc' | 'fail_rate_desc' | 'avg_delay_asc' | 'avg_delay_desc'
 
 const loading = ref(false)
 const tunUpdating = ref(false)
@@ -695,7 +700,7 @@ const activeSortMode = ref<PoolSortMode>('quality')
 const stagingSortMode = ref<PoolSortMode>('quality')
 const quarantineSortMode = ref<PoolSortMode>('quality')
 const candidateSortMode = ref<PoolSortMode>('last_checked_desc')
-const removedSortMode = ref<'removed_desc' | 'removed_asc' | 'fail_rate_asc' | 'fail_rate_desc' | 'avg_delay_asc' | 'avg_delay_desc'>('removed_desc')
+const removedSortMode = ref<RemovedSortMode>('removed_desc')
 const fullFailureThreshold = ref(20)
 const isCompact = ref(typeof window !== 'undefined' ? window.innerWidth < 768 : false)
 const selectedCandidateIds = ref<string[]>([])
@@ -985,111 +990,6 @@ function delayLabel(node: NodeRecord) {
   return node.avgDelayMs > 0 ? `${node.avgDelayMs}ms` : t('nodePool.delayUnknown')
 }
 
-function failRateValue(node: NodeRecord) {
-  if (!node.totalPings) return Number.POSITIVE_INFINITY
-  return node.failedPings / node.totalPings
-}
-
-function delayValue(node: NodeRecord) {
-  return node.avgDelayMs > 0 ? node.avgDelayMs : Number.POSITIVE_INFINITY
-}
-
-function checkedAtValue(node: NodeRecord) {
-  const value = node.lastCheckedAt || node.statusUpdatedAt || node.addedAt
-  const timestamp = value ? new Date(value).getTime() : 0
-  return Number.isFinite(timestamp) ? timestamp : 0
-}
-
-function removedAtValue(node: NodeRecord) {
-  const value = node.statusUpdatedAt || node.lastEventAt || node.addedAt
-  const timestamp = value ? new Date(value).getTime() : 0
-  return Number.isFinite(timestamp) ? timestamp : 0
-}
-
-function compareNodesByQuality(a: NodeRecord, b: NodeRecord) {
-  const failRateDiff = failRateValue(a) - failRateValue(b)
-  if (failRateDiff !== 0) return failRateDiff
-
-  const delayDiff = delayValue(a) - delayValue(b)
-  if (delayDiff !== 0) return delayDiff
-
-  if (a.consecutiveFails !== b.consecutiveFails) {
-    return a.consecutiveFails - b.consecutiveFails
-  }
-
-  if (a.totalPings !== b.totalPings) {
-    return b.totalPings - a.totalPings
-  }
-
-  return checkedAtValue(b) - checkedAtValue(a)
-}
-
-function compareNullableMetric(aValue: number | null, bValue: number | null, direction: 'asc' | 'desc') {
-  if (aValue == null && bValue == null) return 0
-  if (aValue == null) return 1
-  if (bValue == null) return -1
-  return direction === 'asc' ? aValue - bValue : bValue - aValue
-}
-
-function sortPoolNodes(entries: NodeRecord[], mode: PoolSortMode) {
-  return [...entries].sort((a, b) => {
-    switch (mode) {
-      case 'last_checked_desc':
-        return checkedAtValue(b) - checkedAtValue(a)
-      case 'last_checked_asc':
-        return checkedAtValue(a) - checkedAtValue(b)
-      case 'fail_rate_asc': {
-        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'asc')
-        return diff !== 0 ? diff : compareNodesByQuality(a, b)
-      }
-      case 'fail_rate_desc': {
-        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'desc')
-        return diff !== 0 ? diff : compareNodesByQuality(a, b)
-      }
-      case 'avg_delay_asc': {
-        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'asc')
-        return diff !== 0 ? diff : compareNodesByQuality(a, b)
-      }
-      case 'avg_delay_desc': {
-        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'desc')
-        return diff !== 0 ? diff : compareNodesByQuality(a, b)
-      }
-      default:
-        return compareNodesByQuality(a, b)
-    }
-  })
-}
-
-function sortRemovedNodes(
-  entries: NodeRecord[],
-  mode: 'removed_desc' | 'removed_asc' | 'fail_rate_asc' | 'fail_rate_desc' | 'avg_delay_asc' | 'avg_delay_desc'
-) {
-  return [...entries].sort((a, b) => {
-    switch (mode) {
-      case 'removed_asc':
-        return removedAtValue(a) - removedAtValue(b)
-      case 'fail_rate_asc': {
-        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'asc')
-        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
-      }
-      case 'fail_rate_desc': {
-        const diff = compareNullableMetric(a.totalPings ? failRateValue(a) : null, b.totalPings ? failRateValue(b) : null, 'desc')
-        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
-      }
-      case 'avg_delay_asc': {
-        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'asc')
-        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
-      }
-      case 'avg_delay_desc': {
-        const diff = compareNullableMetric(a.avgDelayMs > 0 ? a.avgDelayMs : null, b.avgDelayMs > 0 ? b.avgDelayMs : null, 'desc')
-        return diff !== 0 ? diff : removedAtValue(b) - removedAtValue(a)
-      }
-      default:
-        return removedAtValue(b) - removedAtValue(a)
-    }
-  })
-}
-
 function formatDateTime(value?: string) {
   if (!value) return ''
   const date = new Date(value)
@@ -1368,17 +1268,6 @@ async function fetchDashboard() {
 async function fetchConfig() {
   const data = await nodePoolAPI.getConfig()
   configForm.value = { ...configForm.value, ...data }
-}
-
-function normalizeListInput(value: string) {
-  return Array.from(
-    new Set(
-      value
-        .split(/[\n,]/)
-        .map((item) => item.trim())
-        .filter(Boolean)
-    )
-  )
 }
 
 function syncTunSettingsTextAreas() {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
@@ -20,6 +21,6 @@
     },
     "baseUrl": "."
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "env.d.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "env.d.ts", "vitest.setup.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
@@ -30,5 +30,10 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: false,
     minify: 'esbuild'
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.test.ts']
   }
 })

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,0 +1,25 @@
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false
+    })
+  })
+}
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  globalThis.ResizeObserver = ResizeObserver as typeof globalThis.ResizeObserver
+}


### PR DESCRIPTION
Closes #8

## Summary

Add a Vitest-based frontend regression harness for the WebPanel, including reusable node-pool sorting helpers, locale parity coverage, and check-script integration so the suite runs locally, on pre-push, and in CI.

## Linked Issue

Closes #8

## Scope

- Added Vitest + jsdom setup for the frontend
- Added regression tests for format helpers, node pool sorting/list normalization, and zh-CN/en locale key parity
- Refactored NodePool sorting/list parsing into reusable tested utilities
- Updated `scripts/check.sh` and README to include frontend tests
- Did not add component-level browser tests in this PR

## Verification

- [x] `bash scripts/check.sh`
- [x] I tested the affected user flow locally

Relevant local verification:
- `npm run test` in `web/`
- `bash scripts/check.sh`

## Risks

Main risk is limited coverage breadth: this PR establishes the harness and covers high-risk utility logic, but broader end-to-end frontend behavior will be expanded in follow-up regression issues.