### PR TITLE
feat: make subscriptions editable and pausable

### DIFF
--- a/app/webpanel/handler_node_pool.go
+++ b/app/webpanel/handler_node_pool.go
@@ -20,7 +20,7 @@ func (wp *WebPanel) handleSubscriptions(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// handleSubscriptionByID handles DELETE /api/v1/subscriptions/:id and POST /api/v1/subscriptions/:id/refresh.
+// handleSubscriptionByID handles PUT /api/v1/subscriptions/:id, DELETE, and POST /api/v1/subscriptions/:id/refresh.
 func (wp *WebPanel) handleSubscriptionByID(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/subscriptions/")
 	parts := strings.SplitN(path, "/", 2)
@@ -42,6 +42,8 @@ func (wp *WebPanel) handleSubscriptionByID(w http.ResponseWriter, r *http.Reques
 	}
 
 	switch r.Method {
+	case http.MethodPut:
+		wp.updateSubscriptionHandler(w, r, id)
 	case http.MethodDelete:
 		wp.deleteSubscriptionHandler(w, r, id)
 	default:
@@ -118,6 +120,52 @@ func (wp *WebPanel) deleteSubscriptionHandler(w http.ResponseWriter, r *http.Req
 
 	writeJSON(w, http.StatusOK, map[string]string{
 		"message": "Subscription deleted successfully",
+	})
+}
+
+func (wp *WebPanel) updateSubscriptionHandler(w http.ResponseWriter, r *http.Request, id string) {
+	if wp.subManager == nil {
+		writeError(w, http.StatusServiceUnavailable, "subscription manager not initialized")
+		return
+	}
+
+	var req struct {
+		SourceType      *string `json:"sourceType"`
+		URL             *string `json:"url"`
+		Remark          *string `json:"remark"`
+		AutoRefresh     *bool   `json:"autoRefresh"`
+		RefreshInterval *int    `json:"refreshIntervalMin"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+
+	var sourceType *SubscriptionSourceType
+	if req.SourceType != nil {
+		value := SubscriptionSourceType(strings.TrimSpace(*req.SourceType))
+		sourceType = &value
+	}
+
+	sub, err := wp.subManager.UpdateSubscription(id, SubscriptionUpdateInput{
+		SourceType:      sourceType,
+		URL:             req.URL,
+		Remark:          req.Remark,
+		AutoRefresh:     req.AutoRefresh,
+		RefreshInterval: req.RefreshInterval,
+	})
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"message":      "Subscription updated successfully",
+		"subscription": sub,
 	})
 }
 

--- a/app/webpanel/subscription_manager.go
+++ b/app/webpanel/subscription_manager.go
@@ -173,6 +173,14 @@ type SubscriptionInput struct {
 	RefreshInterval int
 }
 
+type SubscriptionUpdateInput struct {
+	SourceType      *SubscriptionSourceType
+	URL             *string
+	Remark          *string
+	AutoRefresh     *bool
+	RefreshInterval *int
+}
+
 // NodeRecord represents a node in the pool.
 type NodeRecord struct {
 	ID               string            `json:"id"`
@@ -213,19 +221,19 @@ type ValidationConfig struct {
 
 // SubscriptionManager manages subscriptions and the node pool lifecycle.
 type SubscriptionManager struct {
-	mu                 sync.RWMutex
-	state              *NodePoolState
-	statePath          string
-	grpcClient         *GRPCClient
-	prober             *NodeProber
-	instance           *core.Instance
-	runtimeCtx         context.Context
-	stopCh             chan struct{}
-	refreshMu          sync.Mutex
-	saveCh             chan struct{}
-	saveDelay          time.Duration
-	onPoolHealthChange func(PoolHealthSummary)
-	bgWG               sync.WaitGroup
+	mu                  sync.RWMutex
+	state               *NodePoolState
+	statePath           string
+	grpcClient          *GRPCClient
+	prober              *NodeProber
+	instance            *core.Instance
+	runtimeCtx          context.Context
+	stopCh              chan struct{}
+	refreshMu           sync.Mutex
+	saveCh              chan struct{}
+	saveDelay           time.Duration
+	onPoolHealthChange  func(PoolHealthSummary)
+	bgWG                sync.WaitGroup
 }
 
 const (
@@ -350,8 +358,7 @@ func (sm *SubscriptionManager) ListSubscriptions() []SubscriptionRecord {
 	result := make([]SubscriptionRecord, len(sm.state.Subscriptions))
 	copy(result, sm.state.Subscriptions)
 	for i := range result {
-		result[i].SourceType = normalizeSubscriptionSourceType(result[i].SourceType)
-		result[i].Content = ""
+		result[i] = copySubscriptionRecordForAPI(result[i])
 		count := 0
 		for _, n := range sm.state.Nodes {
 			if n.SubscriptionID == result[i].ID && isCountedSubscriptionNode(n) {
@@ -371,17 +378,15 @@ func (sm *SubscriptionManager) AddSubscription(input SubscriptionInput) (*Subscr
 	}
 
 	sm.mu.Lock()
-	for _, s := range sm.state.Subscriptions {
-		if s.ID == rec.ID {
-			sm.mu.Unlock()
-			return nil, fmt.Errorf("subscription already exists")
-		}
+	if sm.subscriptionSourceExistsLocked(rec, "") {
+		sm.mu.Unlock()
+		return nil, fmt.Errorf("subscription already exists")
 	}
 	sm.state.Subscriptions = append(sm.state.Subscriptions, rec)
 	sm.writeStateLocked()
 	sm.mu.Unlock()
 
-	if err := sm.refreshSubscription(rec.ID); err != nil {
+	if err := sm.RefreshSubscription(rec.ID); err != nil {
 		sm.mu.Lock()
 		sm.removeSubscriptionLocked(rec.ID)
 		sm.writeStateLocked()
@@ -393,12 +398,103 @@ func (sm *SubscriptionManager) AddSubscription(input SubscriptionInput) (*Subscr
 	defer sm.mu.RUnlock()
 	for _, s := range sm.state.Subscriptions {
 		if s.ID == rec.ID {
-			copyRec := s
-			copyRec.Content = ""
+			copyRec := copySubscriptionRecordForAPI(s)
 			return &copyRec, nil
 		}
 	}
 	return nil, fmt.Errorf("subscription disappeared after creation")
+}
+
+func (sm *SubscriptionManager) UpdateSubscription(id string, input SubscriptionUpdateInput) (*SubscriptionRecord, error) {
+	sm.refreshMu.Lock()
+	defer sm.refreshMu.Unlock()
+
+	sm.mu.Lock()
+	idx := sm.findSubscriptionIndexLocked(id)
+	if idx < 0 {
+		sm.mu.Unlock()
+		return nil, fmt.Errorf("subscription not found")
+	}
+
+	current := sm.state.Subscriptions[idx]
+	current.SourceType = normalizeSubscriptionSourceType(current.SourceType)
+	updated := current
+
+	if input.SourceType != nil {
+		requestedType := normalizeSubscriptionSourceType(*input.SourceType)
+		if requestedType != current.SourceType {
+			sm.mu.Unlock()
+			return nil, fmt.Errorf("subscription source type cannot be changed")
+		}
+	}
+	if input.Remark != nil {
+		updated.Remark = strings.TrimSpace(*input.Remark)
+	}
+
+	requiresRefresh := false
+	switch current.SourceType {
+	case SubscriptionSourceURL:
+		if input.URL != nil {
+			updatedURL := strings.TrimSpace(*input.URL)
+			if updatedURL == "" {
+				sm.mu.Unlock()
+				return nil, fmt.Errorf("subscription URL is required")
+			}
+			if updated.URL != updatedURL {
+				updated.URL = updatedURL
+				requiresRefresh = true
+			}
+		}
+		if input.AutoRefresh != nil {
+			updated.AutoRefresh = *input.AutoRefresh
+		}
+		if input.RefreshInterval != nil {
+			updated.RefreshInterval = *input.RefreshInterval
+		}
+	case SubscriptionSourceManual, SubscriptionSourceFile:
+		if input.URL != nil {
+			sm.mu.Unlock()
+			return nil, fmt.Errorf("only URL subscriptions support URL updates")
+		}
+		if input.AutoRefresh != nil || input.RefreshInterval != nil {
+			sm.mu.Unlock()
+			return nil, fmt.Errorf("only URL subscriptions support refresh policy updates")
+		}
+	default:
+		sm.mu.Unlock()
+		return nil, fmt.Errorf("unsupported subscription source type: %s", current.SourceType)
+	}
+
+	normalizeSubscriptionRecord(&updated)
+	if sm.subscriptionSourceExistsLocked(updated, id) {
+		sm.mu.Unlock()
+		return nil, fmt.Errorf("subscription already exists")
+	}
+
+	sm.state.Subscriptions[idx] = updated
+	sm.writeStateLocked()
+	sm.mu.Unlock()
+
+	if requiresRefresh {
+		if err := sm.refreshSubscriptionLocked(id); err != nil {
+			sm.mu.Lock()
+			if rollbackIdx := sm.findSubscriptionIndexLocked(id); rollbackIdx >= 0 {
+				sm.state.Subscriptions[rollbackIdx] = current
+				sm.writeStateLocked()
+			}
+			sm.mu.Unlock()
+			return nil, fmt.Errorf("failed to refresh updated subscription: %w", err)
+		}
+	}
+
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	idx = sm.findSubscriptionIndexLocked(id)
+	if idx < 0 {
+		return nil, fmt.Errorf("subscription disappeared after update")
+	}
+	copyRec := copySubscriptionRecordForAPI(sm.state.Subscriptions[idx])
+	return &copyRec, nil
 }
 
 // DeleteSubscription removes a subscription and marks its nodes removed.
@@ -436,7 +532,9 @@ func (sm *SubscriptionManager) DeleteSubscription(id string) error {
 
 // RefreshSubscription triggers a refresh of a specific subscription.
 func (sm *SubscriptionManager) RefreshSubscription(id string) error {
-	return sm.refreshSubscription(id)
+	sm.refreshMu.Lock()
+	defer sm.refreshMu.Unlock()
+	return sm.refreshSubscriptionLocked(id)
 }
 
 // ListNodes returns nodes filtered by status (empty string = all).
@@ -834,10 +932,7 @@ func (sm *SubscriptionManager) BulkRemove(filter BulkRemoveFilter) (int, error) 
 	return removed, nil
 }
 
-func (sm *SubscriptionManager) refreshSubscription(id string) error {
-	sm.refreshMu.Lock()
-	defer sm.refreshMu.Unlock()
-
+func (sm *SubscriptionManager) refreshSubscriptionLocked(id string) error {
 	sm.mu.RLock()
 	var sub *SubscriptionRecord
 	for i := range sm.state.Subscriptions {
@@ -1226,6 +1321,27 @@ func (sm *SubscriptionManager) removeSubscriptionLocked(id string) {
 	sm.state.Subscriptions = remaining
 }
 
+func (sm *SubscriptionManager) findSubscriptionIndexLocked(id string) int {
+	for i := range sm.state.Subscriptions {
+		if sm.state.Subscriptions[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func (sm *SubscriptionManager) subscriptionSourceExistsLocked(candidate SubscriptionRecord, excludeID string) bool {
+	for _, existing := range sm.state.Subscriptions {
+		if existing.ID == excludeID {
+			continue
+		}
+		if sameSubscriptionSource(existing, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
 func (sm *SubscriptionManager) findNodeByTag(tag string) int {
 	for i, n := range sm.state.Nodes {
 		if n.OutboundTag == tag {
@@ -1256,7 +1372,7 @@ func (sm *SubscriptionManager) autoRefreshLoop() {
 				if sub.LastRefresh != nil && time.Since(*sub.LastRefresh) < time.Duration(sub.RefreshInterval)*time.Minute {
 					continue
 				}
-				if err := sm.refreshSubscription(sub.ID); err != nil {
+				if err := sm.RefreshSubscription(sub.ID); err != nil {
 					errors.LogWarning(context.Background(), "node pool: auto-refresh failed for ", sub.Remark, ": ", err.Error())
 				}
 			}
@@ -1543,6 +1659,29 @@ func buildSubscriptionRecord(input SubscriptionInput) (SubscriptionRecord, error
 	}
 
 	return rec, nil
+}
+
+func copySubscriptionRecordForAPI(sub SubscriptionRecord) SubscriptionRecord {
+	sub.SourceType = normalizeSubscriptionSourceType(sub.SourceType)
+	sub.Content = ""
+	return sub
+}
+
+func sameSubscriptionSource(a, b SubscriptionRecord) bool {
+	sourceType := normalizeSubscriptionSourceType(a.SourceType)
+	if sourceType != normalizeSubscriptionSourceType(b.SourceType) {
+		return false
+	}
+
+	switch sourceType {
+	case SubscriptionSourceURL:
+		return strings.TrimSpace(a.URL) == strings.TrimSpace(b.URL)
+	case SubscriptionSourceManual, SubscriptionSourceFile:
+		return strings.TrimSpace(a.SourceName) == strings.TrimSpace(b.SourceName) &&
+			strings.TrimSpace(trimUTF8BOM(a.Content)) == strings.TrimSpace(trimUTF8BOM(b.Content))
+	default:
+		return false
+	}
 }
 
 func normalizeSubscriptionRecord(sub *SubscriptionRecord) bool {

--- a/app/webpanel/subscription_manager_test.go
+++ b/app/webpanel/subscription_manager_test.go
@@ -3,6 +3,8 @@ package webpanel
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -906,7 +908,7 @@ func TestSubscriptionManagerRefreshSubscriptionParksMissingNodesInCandidate(t *t
 	}
 	sm.mu.Unlock()
 
-	if err := sm.refreshSubscription(subID); err != nil {
+	if err := sm.RefreshSubscription(subID); err != nil {
 		t.Fatalf("initial refresh subscription: %v", err)
 	}
 
@@ -928,7 +930,7 @@ func TestSubscriptionManagerRefreshSubscriptionParksMissingNodesInCandidate(t *t
 	sm.state.Subscriptions[0].Content = liveURI
 	sm.mu.Unlock()
 
-	if err := sm.refreshSubscription(subID); err != nil {
+	if err := sm.RefreshSubscription(subID); err != nil {
 		t.Fatalf("second refresh subscription: %v", err)
 	}
 
@@ -998,7 +1000,7 @@ func TestSubscriptionManagerRefreshSubscriptionReintroducesCandidateMissingNode(
 	}
 	sm.mu.Unlock()
 
-	if err := sm.refreshSubscription(subID); err != nil {
+	if err := sm.RefreshSubscription(subID); err != nil {
 		t.Fatalf("initial refresh subscription: %v", err)
 	}
 
@@ -1018,7 +1020,7 @@ func TestSubscriptionManagerRefreshSubscriptionReintroducesCandidateMissingNode(
 	sm.state.Nodes[0].LastEventAt = timePtr(now)
 	sm.mu.Unlock()
 
-	if err := sm.refreshSubscription(subID); err != nil {
+	if err := sm.RefreshSubscription(subID); err != nil {
 		t.Fatalf("second refresh subscription: %v", err)
 	}
 
@@ -1038,6 +1040,316 @@ func TestSubscriptionManagerRefreshSubscriptionReintroducesCandidateMissingNode(
 	if len(handlerStub.addedTags) != 1 || handlerStub.addedTags[0] != probeOutboundTag(nodeID) {
 		t.Fatalf("expected outbound %q to be added once, got %v", probeOutboundTag(nodeID), handlerStub.addedTags)
 	}
+}
+
+func TestSubscriptionManagerUpdateSubscriptionMetadataKeepsNodeHistory(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	handlerStub := &stubHandlerServiceClient{}
+	sm := NewSubscriptionManager(configPath, &GRPCClient{handlerClient: handlerStub}, nil, nil)
+	defer sm.Stop()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(
+			"vless://11111111-1111-1111-1111-111111111111@meta.example.com:443?security=tls&sni=meta.example.com#meta-node\n",
+		))
+	}))
+	defer server.Close()
+
+	sub, err := sm.AddSubscription(SubscriptionInput{
+		SourceType:      SubscriptionSourceURL,
+		URL:             server.URL,
+		Remark:          "url sub",
+		AutoRefresh:     true,
+		RefreshInterval: 60,
+	})
+	if err != nil {
+		t.Fatalf("add URL subscription: %v", err)
+	}
+
+	nodes := sm.ListNodes("")
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	originalNode := nodes[0]
+
+	updated, err := sm.UpdateSubscription(sub.ID, SubscriptionUpdateInput{
+		SourceType:      sourceTypePtr(SubscriptionSourceURL),
+		Remark:          stringPtr("updated remark"),
+		AutoRefresh:     boolPtr(false),
+		RefreshInterval: intPtr(120),
+	})
+	if err != nil {
+		t.Fatalf("update subscription metadata: %v", err)
+	}
+
+	if updated.ID != sub.ID {
+		t.Fatalf("expected subscription ID to remain %q, got %q", sub.ID, updated.ID)
+	}
+	if updated.Remark != "updated remark" {
+		t.Fatalf("expected updated remark, got %q", updated.Remark)
+	}
+	if updated.AutoRefresh {
+		t.Fatal("expected auto-refresh to be disabled after pause")
+	}
+	if updated.RefreshInterval != 120 {
+		t.Fatalf("expected refresh interval 120, got %d", updated.RefreshInterval)
+	}
+
+	nodes = sm.ListNodes("")
+	if len(nodes) != 1 {
+		t.Fatalf("expected node count to remain 1, got %d", len(nodes))
+	}
+	if nodes[0].ID != originalNode.ID {
+		t.Fatalf("expected node ID %q to remain unchanged, got %q", originalNode.ID, nodes[0].ID)
+	}
+	if len(handlerStub.addedTags) != 1 {
+		t.Fatalf("expected no extra outbound registrations during metadata-only update, got %v", handlerStub.addedTags)
+	}
+	if len(handlerStub.removedTags) != 0 {
+		t.Fatalf("expected no outbound removals during metadata-only update, got %v", handlerStub.removedTags)
+	}
+
+	listed := sm.ListSubscriptions()
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(listed))
+	}
+	if listed[0].ID != sub.ID {
+		t.Fatalf("expected listed subscription ID %q, got %q", sub.ID, listed[0].ID)
+	}
+	if listed[0].AutoRefresh {
+		t.Fatal("expected listed subscription auto-refresh to stay disabled")
+	}
+}
+
+func TestSubscriptionManagerUpdateSubscriptionURLReconcilesNodesInPlace(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	handlerStub := &stubHandlerServiceClient{}
+	sm := NewSubscriptionManager(configPath, &GRPCClient{handlerClient: handlerStub}, nil, nil)
+	defer sm.Stop()
+
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(
+			"vless://22222222-2222-2222-2222-222222222222@update-a.example.com:443?security=tls&sni=update-a.example.com#update-a\n",
+		))
+	}))
+	defer serverA.Close()
+
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(
+			"vless://33333333-3333-3333-3333-333333333333@update-b.example.com:443?security=tls&sni=update-b.example.com#update-b\n",
+		))
+	}))
+	defer serverB.Close()
+
+	sub, err := sm.AddSubscription(SubscriptionInput{
+		SourceType:      SubscriptionSourceURL,
+		URL:             serverA.URL,
+		Remark:          "url sub",
+		AutoRefresh:     false,
+		RefreshInterval: 60,
+	})
+	if err != nil {
+		t.Fatalf("add URL subscription: %v", err)
+	}
+
+	nodes := sm.ListNodes("")
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	originalNodeID := nodes[0].ID
+
+	updated, err := sm.UpdateSubscription(sub.ID, SubscriptionUpdateInput{
+		URL: stringPtr(serverB.URL),
+	})
+	if err != nil {
+		t.Fatalf("update subscription URL: %v", err)
+	}
+
+	if updated.ID != sub.ID {
+		t.Fatalf("expected subscription ID to remain %q, got %q", sub.ID, updated.ID)
+	}
+	if updated.URL != serverB.URL {
+		t.Fatalf("expected updated URL %q, got %q", serverB.URL, updated.URL)
+	}
+
+	nodes = sm.ListNodes("")
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes after reconciliation, got %d", len(nodes))
+	}
+
+	statusByID := make(map[string]NodeStatus, len(nodes))
+	reasonByID := make(map[string]TransitionReason, len(nodes))
+	subscriptionByID := make(map[string]string, len(nodes))
+	addressByID := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		statusByID[node.ID] = node.Status
+		reasonByID[node.ID] = node.StatusReason
+		subscriptionByID[node.ID] = node.SubscriptionID
+		addressByID[node.ID] = node.Address
+	}
+
+	if statusByID[originalNodeID] != NodeStatusCandidate {
+		t.Fatalf("expected original node to move to candidate, got %q", statusByID[originalNodeID])
+	}
+	if reasonByID[originalNodeID] != TransitionReasonSubscriptionMissing {
+		t.Fatalf("expected original node reason subscription_missing, got %q", reasonByID[originalNodeID])
+	}
+	if subscriptionByID[originalNodeID] != sub.ID {
+		t.Fatalf("expected original node subscription ID %q, got %q", sub.ID, subscriptionByID[originalNodeID])
+	}
+
+	replacementCount := 0
+	for nodeID, address := range addressByID {
+		if address != "update-b.example.com" {
+			continue
+		}
+		replacementCount++
+		if statusByID[nodeID] != NodeStatusStaging {
+			t.Fatalf("expected replacement node to be staging, got %q", statusByID[nodeID])
+		}
+		if reasonByID[nodeID] != TransitionReasonSubscriptionNodeDiscovered {
+			t.Fatalf("expected replacement node reason subscription_node_discovered, got %q", reasonByID[nodeID])
+		}
+		if subscriptionByID[nodeID] != sub.ID {
+			t.Fatalf("expected replacement node subscription ID %q, got %q", sub.ID, subscriptionByID[nodeID])
+		}
+	}
+	if replacementCount != 1 {
+		t.Fatalf("expected 1 replacement node, got %d", replacementCount)
+	}
+
+	if len(handlerStub.addedTags) != 2 {
+		t.Fatalf("expected two outbound registrations after URL update, got %v", handlerStub.addedTags)
+	}
+}
+
+func TestSubscriptionManagerUpdateSubscriptionRejectsDuplicateURL(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	handlerStub := &stubHandlerServiceClient{}
+	sm := NewSubscriptionManager(configPath, &GRPCClient{handlerClient: handlerStub}, nil, nil)
+	defer sm.Stop()
+
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(
+			"vless://44444444-4444-4444-4444-444444444444@dup-a.example.com:443?security=tls&sni=dup-a.example.com#dup-a\n",
+		))
+	}))
+	defer serverA.Close()
+
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(
+			"vless://55555555-5555-5555-5555-555555555555@dup-b.example.com:443?security=tls&sni=dup-b.example.com#dup-b\n",
+		))
+	}))
+	defer serverB.Close()
+
+	first, err := sm.AddSubscription(SubscriptionInput{
+		SourceType:      SubscriptionSourceURL,
+		URL:             serverA.URL,
+		Remark:          "first",
+		AutoRefresh:     false,
+		RefreshInterval: 60,
+	})
+	if err != nil {
+		t.Fatalf("add first subscription: %v", err)
+	}
+	second, err := sm.AddSubscription(SubscriptionInput{
+		SourceType:      SubscriptionSourceURL,
+		URL:             serverB.URL,
+		Remark:          "second",
+		AutoRefresh:     false,
+		RefreshInterval: 60,
+	})
+	if err != nil {
+		t.Fatalf("add second subscription: %v", err)
+	}
+
+	if _, err := sm.UpdateSubscription(first.ID, SubscriptionUpdateInput{URL: stringPtr(serverB.URL)}); err == nil {
+		t.Fatal("expected duplicate URL update to fail")
+	}
+
+	listed := sm.ListSubscriptions()
+	if len(listed) != 2 {
+		t.Fatalf("expected 2 subscriptions, got %d", len(listed))
+	}
+	urlByID := map[string]string{}
+	for _, sub := range listed {
+		urlByID[sub.ID] = sub.URL
+	}
+	if urlByID[first.ID] != serverA.URL {
+		t.Fatalf("expected first subscription URL to remain %q, got %q", serverA.URL, urlByID[first.ID])
+	}
+	if urlByID[second.ID] != serverB.URL {
+		t.Fatalf("expected second subscription URL to remain %q, got %q", serverB.URL, urlByID[second.ID])
+	}
+}
+
+func TestSubscriptionManagerUpdateManualSubscriptionOnlyAllowsRemark(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	sm := NewSubscriptionManager(configPath, nil, nil, nil)
+	defer sm.Stop()
+
+	sub, err := sm.AddSubscription(SubscriptionInput{
+		SourceType: SubscriptionSourceManual,
+		Content:    "vless://88888888-8888-8888-8888-888888888888@manual.example.com:443?security=tls&sni=manual.example.com#manual-node",
+		Remark:     "manual source",
+	})
+	if err != nil {
+		t.Fatalf("add manual subscription: %v", err)
+	}
+
+	updated, err := sm.UpdateSubscription(sub.ID, SubscriptionUpdateInput{
+		SourceType: sourceTypePtr(SubscriptionSourceManual),
+		Remark:     stringPtr("manual source updated"),
+	})
+	if err != nil {
+		t.Fatalf("update manual remark: %v", err)
+	}
+	if updated.ID != sub.ID {
+		t.Fatalf("expected ID %q to remain unchanged, got %q", sub.ID, updated.ID)
+	}
+	if updated.Remark != "manual source updated" {
+		t.Fatalf("expected updated remark, got %q", updated.Remark)
+	}
+
+	if _, err := sm.UpdateSubscription(sub.ID, SubscriptionUpdateInput{
+		URL: stringPtr("https://example.com/sub.txt"),
+	}); err == nil {
+		t.Fatal("expected manual source URL update to fail")
+	}
+	if _, err := sm.UpdateSubscription(sub.ID, SubscriptionUpdateInput{
+		AutoRefresh: boolPtr(true),
+	}); err == nil {
+		t.Fatal("expected manual source autoRefresh update to fail")
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func sourceTypePtr(value SubscriptionSourceType) *SubscriptionSourceType {
+	return &value
 }
 
 func timePtr(value time.Time) *time.Time {

--- a/tests/test_web_smoke.py
+++ b/tests/test_web_smoke.py
@@ -327,6 +327,125 @@ class WebSmokeTest(unittest.TestCase):
                             {"ids": [node_id]},
                         )
 
+    def test_update_subscription_and_toggle_auto_refresh(self) -> None:
+        initial_link = (
+            "vless://66666666-6666-6666-6666-666666666666@edit-a.example.com:443"
+            "?encryption=none&security=tls&sni=edit-a.example.com&type=tcp#edit-a"
+        )
+        updated_link = (
+            "vless://77777777-7777-7777-7777-777777777777@edit-b.example.com:443"
+            "?encryption=none&security=tls&sni=edit-b.example.com&type=tcp#edit-b"
+        )
+        subscription_id = None
+        original_node_id = None
+        replacement_node_id = None
+
+        with serve_subscription_content(f"{initial_link}\n") as (subscription_url_a, _):
+            with serve_subscription_content(f"{updated_link}\n") as (subscription_url_b, _):
+                try:
+                    created = self.api_json(
+                        "POST",
+                        "/api/v1/subscriptions",
+                        {
+                            "url": subscription_url_a,
+                            "sourceType": "url",
+                            "remark": "editable-subscription",
+                            "autoRefresh": True,
+                            "refreshIntervalMin": 60,
+                        },
+                    )
+                    subscription = created["subscription"]
+                    subscription_id = subscription["id"]
+
+                    initial_pool = self.wait_for_api(
+                        "/api/v1/node-pool",
+                        lambda data: any(item["subscriptionId"] == subscription_id for item in data["nodes"]),
+                    )
+                    original_node = next(
+                        item for item in initial_pool["nodes"] if item["subscriptionId"] == subscription_id
+                    )
+                    original_node_id = original_node["id"]
+                    self.assertEqual(original_node["address"], "edit-a.example.com")
+
+                    updated = self.api_json(
+                        "PUT",
+                        f"/api/v1/subscriptions/{subscription_id}",
+                        {
+                            "sourceType": "url",
+                            "url": subscription_url_b,
+                            "remark": "editable-subscription-updated",
+                            "autoRefresh": False,
+                            "refreshIntervalMin": 120,
+                        },
+                    )
+                    updated_subscription = updated["subscription"]
+                    self.assertEqual(updated_subscription["id"], subscription_id)
+                    self.assertEqual(updated_subscription["url"], subscription_url_b)
+                    self.assertEqual(updated_subscription["remark"], "editable-subscription-updated")
+                    self.assertFalse(updated_subscription["autoRefresh"])
+                    self.assertEqual(updated_subscription["refreshIntervalMin"], 120)
+
+                    reconciled_pool = self.wait_for_api(
+                        "/api/v1/node-pool",
+                        lambda data: any(
+                            item["id"] == original_node_id
+                            and item["status"] == "candidate"
+                            and item["statusReason"] == "subscription_missing"
+                            for item in data["nodes"]
+                        )
+                        and any(
+                            item["subscriptionId"] == subscription_id and item["address"] == "edit-b.example.com"
+                            for item in data["nodes"]
+                        ),
+                    )
+                    replacement_node = next(
+                        item
+                        for item in reconciled_pool["nodes"]
+                        if item["subscriptionId"] == subscription_id and item["address"] == "edit-b.example.com"
+                    )
+                    replacement_node_id = replacement_node["id"]
+                    self.assertEqual(replacement_node["status"], "staging")
+
+                    listed = self.api_get("/api/v1/subscriptions")
+                    listed_subscription = next(
+                        item for item in listed["subscriptions"] if item["id"] == subscription_id
+                    )
+                    self.assertEqual(listed_subscription["url"], subscription_url_b)
+                    self.assertFalse(listed_subscription["autoRefresh"])
+                    self.assertEqual(listed_subscription["refreshIntervalMin"], 120)
+
+                    resumed = self.api_json(
+                        "PUT",
+                        f"/api/v1/subscriptions/{subscription_id}",
+                        {
+                            "sourceType": "url",
+                            "autoRefresh": True,
+                        },
+                    )
+                    resumed_subscription = resumed["subscription"]
+                    self.assertEqual(resumed_subscription["id"], subscription_id)
+                    self.assertTrue(resumed_subscription["autoRefresh"])
+                    self.assertEqual(resumed_subscription["refreshIntervalMin"], 120)
+
+                    listed = self.api_get("/api/v1/subscriptions")
+                    listed_subscription = next(
+                        item for item in listed["subscriptions"] if item["id"] == subscription_id
+                    )
+                    self.assertTrue(listed_subscription["autoRefresh"])
+                    self.assertEqual(listed_subscription["refreshIntervalMin"], 120)
+                finally:
+                    if subscription_id is not None:
+                        with contextlib.suppress(Exception):
+                            self.api_json("DELETE", f"/api/v1/subscriptions/{subscription_id}")
+                    removable_ids = [node_id for node_id in (original_node_id, replacement_node_id) if node_id]
+                    if removable_ids:
+                        with contextlib.suppress(Exception):
+                            self.api_json(
+                                "POST",
+                                "/api/v1/node-pool/bulk-purge-removed",
+                                {"ids": removable_ids},
+                            )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
 import type {
   NodePoolDashboardResponse,
-  SubscriptionSourceType,
+  SubscriptionCreateRequest,
+  SubscriptionUpdateRequest,
   TunEditableSettings,
   TunStatusResponse,
   UpdateStatusResponse,
@@ -116,16 +117,10 @@ export const shareAPI = {
 
 export const subscriptionAPI = {
   list: () => apiClient.get('/subscriptions') as Promise<any>,
-  add: (data: {
-    url?: string
-    content?: string
-    sourceName?: string
-    sourceType?: SubscriptionSourceType
-    remark: string
-    autoRefresh: boolean
-    refreshIntervalMin: number
-  }) =>
+  add: (data: SubscriptionCreateRequest) =>
     apiClient.post('/subscriptions', data) as Promise<any>,
+  update: (id: string, data: SubscriptionUpdateRequest) =>
+    apiClient.put(`/subscriptions/${id}`, data) as Promise<any>,
   delete: (id: string) => apiClient.delete(`/subscriptions/${id}`) as Promise<any>,
   refresh: (id: string) => apiClient.post(`/subscriptions/${id}/refresh`) as Promise<any>
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -108,6 +108,24 @@ export interface SubscriptionRecord {
   nodeCount: number
 }
 
+export interface SubscriptionUpdateRequest {
+  sourceType?: SubscriptionSourceType
+  url?: string
+  remark?: string
+  autoRefresh?: boolean
+  refreshIntervalMin?: number
+}
+
+export interface SubscriptionCreateRequest {
+  url?: string
+  content?: string
+  sourceName?: string
+  sourceType?: SubscriptionSourceType
+  remark: string
+  autoRefresh: boolean
+  refreshIntervalMin: number
+}
+
 export type NodeStatus = 'candidate' | 'staging' | 'active' | 'quarantine' | 'removed'
 export type TransitionReason =
   | 'subscription_node_discovered'

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -237,7 +237,11 @@
     "lastRefresh": "Last Refresh",
     "nodeCount": "Nodes",
     "addSubscription": "Add Subscription",
+    "editSubscription": "Edit Subscription",
     "deleteConfirm": "Are you sure to delete this subscription and all its nodes?",
+    "pause": "Pause",
+    "resume": "Resume",
+    "nonUrlEditHint": "For manual and file imports, this edit dialog only changes the remark. Recreate the source if you need to replace the imported content.",
     "refreshNow": "Refresh Now",
     "never": "Never",
     "sourceTypeOptions": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -237,7 +237,11 @@
     "lastRefresh": "上次刷新",
     "nodeCount": "节点数",
     "addSubscription": "添加订阅",
+    "editSubscription": "编辑订阅",
     "deleteConfirm": "确定要删除此订阅及其所有节点吗？",
+    "pause": "暂停",
+    "resume": "恢复",
+    "nonUrlEditHint": "手工导入和本地文件导入当前只支持修改备注。如需替换导入内容，请删除后重新导入。",
     "refreshNow": "立即刷新",
     "never": "从未",
     "sourceTypeOptions": {

--- a/web/src/views/Subscriptions.vue
+++ b/web/src/views/Subscriptions.vue
@@ -2,28 +2,33 @@
   <n-space vertical :size="16">
     <n-space justify="space-between" align="center">
       <h2>{{ t('subscriptions.title') }}</h2>
-      <n-button type="primary" @click="showAdd = true">{{ t('subscriptions.addSubscription') }}</n-button>
+      <n-button type="primary" @click="openAddDialog">{{ t('subscriptions.addSubscription') }}</n-button>
     </n-space>
 
     <n-data-table :columns="columns" :data="subscriptions" :loading="loading" :pagination="{ pageSize: 20 }" />
 
     <n-modal
-      :show="showAdd"
+      :show="showDialog"
       preset="dialog"
-      :title="t('subscriptions.addSubscription')"
+      :title="dialogTitle"
       style="width: 640px"
-      @update:show="handleShowAddChange"
+      @update:show="handleDialogVisibilityChange"
     >
       <n-form :model="form" label-placement="left" label-width="auto">
         <n-form-item :label="t('subscriptions.sourceType')">
-          <n-select v-model:value="form.sourceType" :options="sourceTypeOptions" @update:value="handleSourceTypeChange" />
+          <n-select
+            v-model:value="form.sourceType"
+            :options="sourceTypeOptions"
+            :disabled="isEditing"
+            @update:value="handleSourceTypeChange"
+          />
         </n-form-item>
 
         <n-form-item v-if="form.sourceType === 'url'" :label="t('subscriptions.url')">
           <n-input v-model:value="form.url" placeholder="https://..." />
         </n-form-item>
 
-        <n-form-item v-else-if="form.sourceType === 'manual'" :label="t('subscriptions.manualContent')">
+        <n-form-item v-else-if="!isEditing && form.sourceType === 'manual'" :label="t('subscriptions.manualContent')">
           <n-input
             v-model:value="form.content"
             type="textarea"
@@ -32,7 +37,7 @@
           />
         </n-form-item>
 
-        <n-form-item v-else :label="t('subscriptions.localFile')">
+        <n-form-item v-else-if="!isEditing && form.sourceType === 'file'" :label="t('subscriptions.localFile')">
           <n-space vertical :size="8" class="file-import-block">
             <input ref="fileInputRef" class="hidden-file-input" type="file" :accept="fileAccept" @change="handleFilePicked" />
             <n-space align="center" wrap>
@@ -45,22 +50,31 @@
           </n-space>
         </n-form-item>
 
+        <n-form-item v-else-if="isEditing" :label="t('subscriptions.source')">
+          <n-space vertical :size="8" class="file-import-block">
+            <n-input :value="editSourceSummary" readonly />
+            <div v-if="editingSubscription?.sourceType !== 'url'" class="file-import-meta">
+              {{ t('subscriptions.nonUrlEditHint') }}
+            </div>
+          </n-space>
+        </n-form-item>
+
         <n-form-item :label="t('subscriptions.remark')">
-          <n-input v-model:value="form.remark" placeholder="" />
+          <n-input v-model:value="form.remark" />
         </n-form-item>
 
         <n-form-item v-if="form.sourceType === 'url'" :label="t('subscriptions.autoRefresh')">
           <n-switch v-model:value="form.autoRefresh" />
         </n-form-item>
 
-        <n-form-item v-if="form.sourceType === 'url' && form.autoRefresh" :label="t('subscriptions.refreshInterval')">
+        <n-form-item v-if="form.sourceType === 'url'" :label="t('subscriptions.refreshInterval')">
           <n-input-number v-model:value="form.refreshIntervalMin" :min="5" :max="1440" />
         </n-form-item>
       </n-form>
 
       <template #action>
-        <n-button @click="handleShowAddChange(false)">{{ t('common.cancel') }}</n-button>
-        <n-button type="primary" :loading="saving" @click="handleAdd">{{ t('common.confirm') }}</n-button>
+        <n-button @click="handleDialogVisibilityChange(false)">{{ t('common.cancel') }}</n-button>
+        <n-button type="primary" :loading="saving" @click="handleSubmit">{{ submitLabel }}</n-button>
       </template>
     </n-modal>
   </n-space>
@@ -86,15 +100,21 @@ import {
 } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { subscriptionAPI } from '@/api/client'
-import type { SubscriptionRecord, SubscriptionSourceType } from '@/api/types'
+import type { SubscriptionRecord, SubscriptionSourceType, SubscriptionUpdateRequest } from '@/api/types'
+
+type DialogMode = 'add' | 'edit'
 
 const { t } = useI18n()
 const message = useMessage()
 
 const subscriptions = ref<SubscriptionRecord[]>([])
 const loading = ref(false)
-const showAdd = ref(false)
+const showDialog = ref(false)
+const dialogMode = ref<DialogMode>('add')
 const saving = ref(false)
+const refreshingId = ref<string | null>(null)
+const toggleLoadingId = ref<string | null>(null)
+const editingSubscription = ref<SubscriptionRecord | null>(null)
 const fileInputRef = ref<HTMLInputElement | null>(null)
 
 const fileAccept = '.txt,.sub,.conf,.json,.yaml,.yml'
@@ -112,6 +132,18 @@ function createDefaultForm() {
 }
 
 const form = ref(createDefaultForm())
+
+const isEditing = computed(() => dialogMode.value === 'edit')
+const dialogTitle = computed(() =>
+  isEditing.value ? t('subscriptions.editSubscription') : t('subscriptions.addSubscription')
+)
+const submitLabel = computed(() => (isEditing.value ? t('common.save') : t('common.confirm')))
+const editSourceSummary = computed(() => {
+  if (!editingSubscription.value) {
+    return '-'
+  }
+  return sourceDisplay(editingSubscription.value)
+})
 
 const sourceTypeOptions = computed(() => [
   { label: t('subscriptions.sourceTypeOptions.url'), value: 'url' as SubscriptionSourceType },
@@ -167,34 +199,66 @@ const columns: DataTableColumns<SubscriptionRecord> = [
   {
     title: () => t('common.actions'),
     key: 'actions',
-    width: 200,
+    width: 320,
     render(row) {
-      return h(NSpace, { size: 'small' }, {
-        default: () => [
+      const actions = [
+        h(
+          NButton,
+          {
+            size: 'small',
+            onClick: () => openEditDialog(row)
+          },
+          { default: () => t('common.edit') }
+        )
+      ]
+
+      if (row.sourceType === 'url') {
+        actions.push(
           h(
             NButton,
             {
               size: 'small',
-              onClick: () => handleRefresh(row.id),
-              loading: refreshingId.value === row.id
+              type: row.autoRefresh ? 'warning' : 'success',
+              loading: toggleLoadingId.value === row.id,
+              onClick: () => handleToggleAutoRefresh(row)
             },
-            { default: () => t('subscriptions.refreshNow') }
-          ),
-          h(
-            NPopconfirm,
-            { onPositiveClick: () => handleDelete(row.id) },
-            {
-              trigger: () => h(NButton, { size: 'small', type: 'error' }, { default: () => t('common.delete') }),
-              default: () => t('subscriptions.deleteConfirm')
-            }
+            { default: () => (row.autoRefresh ? t('subscriptions.pause') : t('subscriptions.resume')) }
           )
-        ]
-      })
+        )
+      }
+
+      actions.push(
+        h(
+          NButton,
+          {
+            size: 'small',
+            onClick: () => handleRefresh(row.id),
+            loading: refreshingId.value === row.id
+          },
+          { default: () => t('subscriptions.refreshNow') }
+        )
+      )
+      actions.push(
+        h(
+          NPopconfirm,
+          { onPositiveClick: () => handleDelete(row.id) },
+          {
+            trigger: () => h(NButton, { size: 'small', type: 'error' }, { default: () => t('common.delete') }),
+            default: () => t('subscriptions.deleteConfirm')
+          }
+        )
+      )
+
+      return h(
+        NSpace,
+        { size: 'small', wrap: true },
+        {
+          default: () => actions
+        }
+      )
     }
   }
 ]
-
-const refreshingId = ref<string | null>(null)
 
 function sourceTypeLabel(sourceType: SubscriptionSourceType) {
   return t(`subscriptions.sourceTypeOptions.${sourceType}`)
@@ -221,21 +285,49 @@ function sourceDisplay(row: SubscriptionRecord) {
   return row.url || '-'
 }
 
-function resetForm() {
+function resetDialogState() {
+  dialogMode.value = 'add'
+  editingSubscription.value = null
   form.value = createDefaultForm()
   if (fileInputRef.value) {
     fileInputRef.value.value = ''
   }
 }
 
-function handleShowAddChange(value: boolean) {
-  showAdd.value = value
+function openAddDialog() {
+  resetDialogState()
+  showDialog.value = true
+}
+
+function openEditDialog(row: SubscriptionRecord) {
+  dialogMode.value = 'edit'
+  editingSubscription.value = row
+  form.value = {
+    sourceType: row.sourceType,
+    url: row.url || '',
+    content: '',
+    sourceName: row.sourceName || '',
+    remark: row.remark,
+    autoRefresh: row.autoRefresh,
+    refreshIntervalMin: row.refreshIntervalMin || 60
+  }
+  if (fileInputRef.value) {
+    fileInputRef.value.value = ''
+  }
+  showDialog.value = true
+}
+
+function handleDialogVisibilityChange(value: boolean) {
+  showDialog.value = value
   if (!value) {
-    resetForm()
+    resetDialogState()
   }
 }
 
 function handleSourceTypeChange(value: SubscriptionSourceType) {
+  if (isEditing.value) {
+    return
+  }
   form.value.sourceType = value
   form.value.url = ''
   form.value.content = ''
@@ -282,29 +374,48 @@ async function fetchSubscriptions() {
   }
 }
 
-async function handleAdd() {
+function buildUpdatePayload(): SubscriptionUpdateRequest {
+  const payload: SubscriptionUpdateRequest = {
+    sourceType: form.value.sourceType,
+    remark: form.value.remark
+  }
+
+  if (form.value.sourceType === 'url') {
+    payload.url = form.value.url.trim()
+    payload.autoRefresh = form.value.autoRefresh
+    payload.refreshIntervalMin = form.value.refreshIntervalMin
+  }
+
+  return payload
+}
+
+async function handleSubmit() {
   if (form.value.sourceType === 'url' && !form.value.url.trim()) {
     message.warning(t('subscriptions.urlRequired'))
     return
   }
-  if (form.value.sourceType !== 'url' && !form.value.content.trim()) {
+  if (!isEditing.value && form.value.sourceType !== 'url' && !form.value.content.trim()) {
     message.warning(t('subscriptions.contentRequired'))
     return
   }
 
   saving.value = true
   try {
-    await subscriptionAPI.add({
-      sourceType: form.value.sourceType,
-      url: form.value.sourceType === 'url' ? form.value.url.trim() : undefined,
-      content: form.value.sourceType === 'url' ? undefined : form.value.content,
-      sourceName: form.value.sourceType === 'file' ? form.value.sourceName : undefined,
-      remark: form.value.remark,
-      autoRefresh: form.value.sourceType === 'url' ? form.value.autoRefresh : false,
-      refreshIntervalMin: form.value.sourceType === 'url' ? form.value.refreshIntervalMin : 0
-    })
+    if (isEditing.value && editingSubscription.value) {
+      await subscriptionAPI.update(editingSubscription.value.id, buildUpdatePayload())
+    } else {
+      await subscriptionAPI.add({
+        sourceType: form.value.sourceType,
+        url: form.value.sourceType === 'url' ? form.value.url.trim() : undefined,
+        content: form.value.sourceType === 'url' ? undefined : form.value.content,
+        sourceName: form.value.sourceType === 'file' ? form.value.sourceName : undefined,
+        remark: form.value.remark,
+        autoRefresh: form.value.sourceType === 'url' ? form.value.autoRefresh : false,
+        refreshIntervalMin: form.value.sourceType === 'url' ? form.value.refreshIntervalMin : 0
+      })
+    }
     message.success(t('common.success'))
-    handleShowAddChange(false)
+    handleDialogVisibilityChange(false)
     await fetchSubscriptions()
   } catch (err: any) {
     message.error(err?.error || err?.message || t('common.error'))
@@ -323,6 +434,22 @@ async function handleRefresh(id: string) {
     message.error(err?.error || err?.message || t('common.error'))
   } finally {
     refreshingId.value = null
+  }
+}
+
+async function handleToggleAutoRefresh(row: SubscriptionRecord) {
+  toggleLoadingId.value = row.id
+  try {
+    await subscriptionAPI.update(row.id, {
+      sourceType: row.sourceType,
+      autoRefresh: !row.autoRefresh
+    })
+    message.success(t('common.success'))
+    await fetchSubscriptions()
+  } catch (err: any) {
+    message.error(err?.error || err?.message || t('common.error'))
+  } finally {
+    toggleLoadingId.value = null
   }
 }
 


### PR DESCRIPTION
## Summary
- add WebPanel subscription update support for existing sources
- allow pause/resume of URL subscriptions without deleting them
- cover the new flow with Go, smoke, and locale-parity-backed frontend checks

## Verification
- go test ./app/webpanel/...
- python3 tests/test_web_smoke.py
- bash scripts/check.sh

Closes #13