### PR TITLE
feat: add readiness and diagnostics center

### DIFF
--- a/app/webpanel/handler_readiness.go
+++ b/app/webpanel/handler_readiness.go
@@ -1,0 +1,12 @@
+package webpanel
+
+import "net/http"
+
+func (wp *WebPanel) handleReadiness(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, wp.readinessSnapshot(r.Context()))
+}

--- a/app/webpanel/node_prober.go
+++ b/app/webpanel/node_prober.go
@@ -23,6 +23,14 @@ type ProbeResult struct {
 // ProbeCallback is called after each probe round with results.
 type ProbeCallback func(results []ProbeResult)
 
+// NodeProberSnapshot is a read-only snapshot used by diagnostics surfaces.
+type NodeProberSnapshot struct {
+	Running     bool   `json:"running"`
+	ProbeURL    string `json:"probeUrl"`
+	IntervalSec int    `json:"intervalSec"`
+	TagCount    int    `json:"tagCount"`
+}
+
 // NodeProber performs periodic health checks on nodes via their outbound tags.
 type NodeProber struct {
 	mu         sync.RWMutex
@@ -120,6 +128,24 @@ func (p *NodeProber) GetTags() []string {
 		tags = append(tags, t)
 	}
 	return tags
+}
+
+// Snapshot returns the current diagnostics state of the prober.
+func (p *NodeProber) Snapshot() NodeProberSnapshot {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	intervalSec := 0
+	if p.interval > 0 {
+		intervalSec = int(p.interval / time.Second)
+	}
+
+	return NodeProberSnapshot{
+		Running:     p.running,
+		ProbeURL:    p.probeURL,
+		IntervalSec: intervalSec,
+		TagCount:    len(p.tags),
+	}
 }
 
 func (p *NodeProber) loop() {

--- a/app/webpanel/readiness.go
+++ b/app/webpanel/readiness.go
@@ -1,0 +1,461 @@
+package webpanel
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+)
+
+type ReadinessSeverity string
+
+const (
+	ReadinessSeverityOK       ReadinessSeverity = "ok"
+	ReadinessSeverityWarning  ReadinessSeverity = "warning"
+	ReadinessSeverityBlocking ReadinessSeverity = "blocking"
+)
+
+type ReadinessArea string
+
+const (
+	ReadinessAreaConfig        ReadinessArea = "config"
+	ReadinessAreaSubscriptions ReadinessArea = "subscriptions"
+	ReadinessAreaNodePool      ReadinessArea = "node_pool"
+	ReadinessAreaTun           ReadinessArea = "tun"
+	ReadinessAreaRuntime       ReadinessArea = "runtime"
+	ReadinessAreaUpdates       ReadinessArea = "updates"
+)
+
+type ReadinessCheck struct {
+	Key         string                 `json:"key"`
+	Area        ReadinessArea          `json:"area"`
+	Severity    ReadinessSeverity      `json:"severity"`
+	ActionRoute string                 `json:"actionRoute,omitempty"`
+	Facts       map[string]interface{} `json:"facts,omitempty"`
+}
+
+type ReadinessResponse struct {
+	Healthy       bool             `json:"healthy"`
+	BlockingCount int              `json:"blockingCount"`
+	WarningCount  int              `json:"warningCount"`
+	UpdatedAt     string           `json:"updatedAt"`
+	Checks        []ReadinessCheck `json:"checks"`
+}
+
+func (wp *WebPanel) readinessSnapshot(ctx context.Context) ReadinessResponse {
+	checks := make([]ReadinessCheck, 0, 7)
+	configMap, configPathStatus, configPathFacts := wp.readinessLoadConfig()
+	checks = append(checks, ReadinessCheck{
+		Key:         "config_path",
+		Area:        ReadinessAreaConfig,
+		Severity:    configPathStatus,
+		ActionRoute: "/config",
+		Facts:       configPathFacts,
+	})
+	checks = append(checks, wp.readinessConfigSectionsCheck(configMap))
+	checks = append(checks, wp.readinessSubscriptionsCheck())
+	checks = append(checks, wp.readinessProbingCheck())
+	checks = append(checks, wp.readinessNodePoolCheck())
+	checks = append(checks, wp.readinessTunCheck())
+	checks = append(checks, wp.readinessUpdatesCheck(ctx))
+
+	response := ReadinessResponse{
+		Healthy:   true,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		Checks:    checks,
+	}
+	for _, check := range checks {
+		switch check.Severity {
+		case ReadinessSeverityBlocking:
+			response.BlockingCount++
+			response.Healthy = false
+		case ReadinessSeverityWarning:
+			response.WarningCount++
+		}
+	}
+	return response
+}
+
+func (wp *WebPanel) readinessLoadConfig() (map[string]interface{}, ReadinessSeverity, map[string]interface{}) {
+	configPath := strings.TrimSpace(wp.config.ConfigPath)
+	facts := map[string]interface{}{
+		"path": configPath,
+	}
+	if configPath == "" {
+		facts["status"] = "missing"
+		return nil, ReadinessSeverityBlocking, facts
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		facts["status"] = "not_found"
+		facts["error"] = err.Error()
+		return nil, ReadinessSeverityBlocking, facts
+	}
+	facts["sizeBytes"] = info.Size()
+
+	cfm := NewConfigFileManager(configPath)
+	raw, err := cfm.ReadConfig()
+	if err != nil {
+		facts["status"] = "invalid"
+		facts["error"] = err.Error()
+		return nil, ReadinessSeverityBlocking, facts
+	}
+
+	var configMap map[string]interface{}
+	if err := json.Unmarshal(raw, &configMap); err != nil {
+		facts["status"] = "invalid"
+		facts["error"] = err.Error()
+		return nil, ReadinessSeverityBlocking, facts
+	}
+
+	facts["status"] = "ok"
+	return configMap, ReadinessSeverityOK, facts
+}
+
+func (wp *WebPanel) readinessConfigSectionsCheck(config map[string]interface{}) ReadinessCheck {
+	facts := map[string]interface{}{}
+	if config == nil {
+		facts["status"] = "unavailable"
+		return ReadinessCheck{
+			Key:         "config_sections",
+			Area:        ReadinessAreaConfig,
+			Severity:    ReadinessSeverityBlocking,
+			ActionRoute: "/config",
+			Facts:       facts,
+		}
+	}
+
+	missingSections := make([]string, 0, 3)
+	missingStatsFlags := make([]string, 0, 4)
+
+	if _, ok := config["api"].(map[string]interface{}); !ok {
+		missingSections = append(missingSections, "api")
+	}
+	if _, ok := config["stats"].(map[string]interface{}); !ok {
+		missingSections = append(missingSections, "stats")
+	}
+
+	policy, _ := config["policy"].(map[string]interface{})
+	systemPolicy, _ := policy["system"].(map[string]interface{})
+	for _, key := range []string{
+		"statsInboundUplink",
+		"statsInboundDownlink",
+		"statsOutboundUplink",
+		"statsOutboundDownlink",
+	} {
+		value, ok := systemPolicy[key].(bool)
+		if !ok || !value {
+			missingStatsFlags = append(missingStatsFlags, key)
+		}
+	}
+
+	services := make([]string, 0)
+	apiSection, _ := config["api"].(map[string]interface{})
+	if rawServices, ok := apiSection["services"].([]interface{}); ok {
+		for _, service := range rawServices {
+			if value, ok := service.(string); ok && strings.TrimSpace(value) != "" {
+				services = append(services, strings.TrimSpace(value))
+			}
+		}
+	}
+	missingServices := missingRequiredServices(services)
+
+	facts["status"] = "ok"
+	if len(missingSections) > 0 {
+		facts["status"] = "missing_sections"
+		facts["missingSections"] = missingSections
+	}
+	if len(missingStatsFlags) > 0 {
+		facts["missingStatsFlags"] = missingStatsFlags
+		if facts["status"] == "ok" {
+			facts["status"] = "missing_stats_flags"
+		}
+	}
+	if len(missingServices) > 0 {
+		facts["missingServices"] = missingServices
+		if facts["status"] == "ok" {
+			facts["status"] = "missing_services"
+		}
+	}
+
+	severity := ReadinessSeverityOK
+	if len(missingSections) > 0 {
+		severity = ReadinessSeverityBlocking
+	} else if len(missingStatsFlags) > 0 || len(missingServices) > 0 {
+		severity = ReadinessSeverityWarning
+	}
+
+	return ReadinessCheck{
+		Key:         "config_sections",
+		Area:        ReadinessAreaConfig,
+		Severity:    severity,
+		ActionRoute: "/config",
+		Facts:       facts,
+	}
+}
+
+func missingRequiredServices(services []string) []string {
+	required := []string{
+		"HandlerService",
+		"StatsService",
+		"LoggerService",
+		"RoutingService",
+		"ObservatoryService",
+	}
+	if len(services) == 0 {
+		return append([]string{}, required...)
+	}
+
+	existing := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		existing[strings.TrimSpace(service)] = struct{}{}
+	}
+
+	missing := make([]string, 0, len(required))
+	for _, service := range required {
+		if _, ok := existing[service]; !ok {
+			missing = append(missing, service)
+		}
+	}
+	return missing
+}
+
+func (wp *WebPanel) readinessSubscriptionsCheck() ReadinessCheck {
+	if wp.subManager == nil {
+		return ReadinessCheck{
+			Key:         "subscriptions",
+			Area:        ReadinessAreaSubscriptions,
+			Severity:    ReadinessSeverityBlocking,
+			ActionRoute: "/subscriptions",
+			Facts: map[string]interface{}{
+				"status": "unavailable",
+			},
+		}
+	}
+
+	snapshot := wp.subManager.ReadinessSnapshot()
+	facts := map[string]interface{}{
+		"subscriptionCount": snapshot.SubscriptionCount,
+		"nodeCount":         snapshot.NodeCount,
+		"activeCount":       snapshot.PoolSummary.ActiveCount,
+		"candidateCount":    snapshot.PoolSummary.CandidateCount,
+		"stagingCount":      snapshot.PoolSummary.StagingCount,
+		"quarantineCount":   snapshot.PoolSummary.QuarantineCount,
+		"removedCount":      snapshot.PoolSummary.RemovedCount,
+	}
+
+	severity := ReadinessSeverityOK
+	status := "ok"
+	switch {
+	case snapshot.SubscriptionCount == 0:
+		severity = ReadinessSeverityWarning
+		status = "empty"
+	case snapshot.NodeCount == 0:
+		severity = ReadinessSeverityWarning
+		status = "no_nodes"
+	}
+	facts["status"] = status
+
+	return ReadinessCheck{
+		Key:         "subscriptions",
+		Area:        ReadinessAreaSubscriptions,
+		Severity:    severity,
+		ActionRoute: "/subscriptions",
+		Facts:       facts,
+	}
+}
+
+func (wp *WebPanel) readinessProbingCheck() ReadinessCheck {
+	if wp.subManager == nil {
+		return ReadinessCheck{
+			Key:         "probing",
+			Area:        ReadinessAreaRuntime,
+			Severity:    ReadinessSeverityBlocking,
+			ActionRoute: "/node-pool",
+			Facts: map[string]interface{}{
+				"status": "unavailable",
+			},
+		}
+	}
+
+	snapshot := wp.subManager.ReadinessSnapshot()
+	facts := map[string]interface{}{
+		"started":             snapshot.Started,
+		"dispatcherAvailable": snapshot.DispatcherAvailable,
+		"probeUrl":            snapshot.ProbeURL,
+		"probeIntervalSec":    snapshot.ProbeIntervalSec,
+		"tagCount":            snapshot.Prober.TagCount,
+		"running":             snapshot.Prober.Running,
+	}
+
+	severity := ReadinessSeverityOK
+	status := "ok"
+	switch {
+	case !snapshot.Started:
+		severity = ReadinessSeverityWarning
+		status = "not_started"
+	case !snapshot.DispatcherAvailable:
+		severity = ReadinessSeverityWarning
+		status = "dispatcher_unavailable"
+	case snapshot.Prober.TagCount == 0:
+		severity = ReadinessSeverityWarning
+		status = "idle"
+	case !snapshot.Prober.Running:
+		severity = ReadinessSeverityWarning
+		status = "stopped"
+	default:
+		status = "running"
+	}
+	facts["status"] = status
+
+	return ReadinessCheck{
+		Key:         "probing",
+		Area:        ReadinessAreaRuntime,
+		Severity:    severity,
+		ActionRoute: "/node-pool",
+		Facts:       facts,
+	}
+}
+
+func (wp *WebPanel) readinessNodePoolCheck() ReadinessCheck {
+	if wp.subManager == nil {
+		return ReadinessCheck{
+			Key:         "node_pool",
+			Area:        ReadinessAreaNodePool,
+			Severity:    ReadinessSeverityBlocking,
+			ActionRoute: "/node-pool",
+			Facts: map[string]interface{}{
+				"status": "unavailable",
+			},
+		}
+	}
+
+	snapshot := wp.subManager.ReadinessSnapshot()
+	summary := snapshot.PoolSummary
+	facts := map[string]interface{}{
+		"status":          "ok",
+		"healthy":         summary.Healthy,
+		"activeCount":     summary.ActiveCount,
+		"candidateCount":  summary.CandidateCount,
+		"stagingCount":    summary.StagingCount,
+		"quarantineCount": summary.QuarantineCount,
+		"removedCount":    summary.RemovedCount,
+		"minActiveNodes":  summary.MinActiveNodes,
+	}
+
+	severity := ReadinessSeverityOK
+	switch {
+	case snapshot.NodeCount == 0:
+		severity = ReadinessSeverityWarning
+		facts["status"] = "empty"
+	case !summary.Healthy:
+		severity = ReadinessSeverityWarning
+		facts["status"] = "below_minimum"
+	}
+
+	return ReadinessCheck{
+		Key:         "node_pool",
+		Area:        ReadinessAreaNodePool,
+		Severity:    severity,
+		ActionRoute: "/node-pool",
+		Facts:       facts,
+	}
+}
+
+func (wp *WebPanel) readinessTunCheck() ReadinessCheck {
+	if wp.tunManager == nil {
+		return ReadinessCheck{
+			Key:         "tun",
+			Area:        ReadinessAreaTun,
+			Severity:    ReadinessSeverityWarning,
+			ActionRoute: "/settings",
+			Facts: map[string]interface{}{
+				"status": "unavailable",
+			},
+		}
+	}
+
+	status := wp.tunStatusSnapshot()
+	facts := map[string]interface{}{
+		"status":                      status.Status,
+		"running":                     status.Running,
+		"available":                   status.Available,
+		"message":                     status.Message,
+		"helperExists":                status.HelperExists,
+		"elevationReady":              status.ElevationReady,
+		"privilegeInstallRecommended": status.PrivilegeInstallRecommended,
+		"machineState":                status.MachineState,
+	}
+
+	severity := ReadinessSeverityOK
+	switch {
+	case status.MachineState == MachineStateDegraded || status.Status == "error":
+		severity = ReadinessSeverityBlocking
+	case status.Status == "blocked" || status.Status == "unavailable" || status.PrivilegeInstallRecommended || !status.HelperExists:
+		severity = ReadinessSeverityWarning
+	}
+
+	return ReadinessCheck{
+		Key:         "tun",
+		Area:        ReadinessAreaTun,
+		Severity:    severity,
+		ActionRoute: "/settings",
+		Facts:       facts,
+	}
+}
+
+func (wp *WebPanel) readinessUpdatesCheck(ctx context.Context) ReadinessCheck {
+	if wp.releaseChecker == nil {
+		return ReadinessCheck{
+			Key:         "updates",
+			Area:        ReadinessAreaUpdates,
+			Severity:    ReadinessSeverityWarning,
+			ActionRoute: "/dashboard",
+			Facts: map[string]interface{}{
+				"status": "unavailable",
+			},
+		}
+	}
+
+	checkCtx := ctx
+	if checkCtx == nil {
+		checkCtx = context.Background()
+	}
+	checkCtx, cancel := context.WithTimeout(checkCtx, 2*time.Second)
+	defer cancel()
+
+	status := wp.releaseChecker.Check(checkCtx, false)
+	facts := map[string]interface{}{
+		"status":            status.Status,
+		"source":            status.Source,
+		"currentVersion":    status.CurrentVersion,
+		"latestVersion":     status.LatestVersion,
+		"updateAvailable":   status.UpdateAvailable,
+		"message":           status.Message,
+		"latestPublishedAt": status.LatestPublishedAt,
+	}
+
+	severity := ReadinessSeverityOK
+	if status.Status == "error" || status.Status == "stale" || status.UpdateAvailable {
+		severity = ReadinessSeverityWarning
+	}
+
+	return ReadinessCheck{
+		Key:         "updates",
+		Area:        ReadinessAreaUpdates,
+		Severity:    severity,
+		ActionRoute: "/dashboard",
+		Facts:       facts,
+	}
+}
+
+func readinessCheckByKey(checks []ReadinessCheck, key string) (ReadinessCheck, bool) {
+	for _, check := range checks {
+		if check.Key == key {
+			return check, true
+		}
+	}
+	return ReadinessCheck{}, false
+}

--- a/app/webpanel/readiness_test.go
+++ b/app/webpanel/readiness_test.go
@@ -1,0 +1,153 @@
+package webpanel
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWebPanelReadinessSnapshotBlocksWhenConfigPathMissing(t *testing.T) {
+	t.Parallel()
+
+	wp := &WebPanel{
+		config:         &Config{},
+		releaseChecker: cachedReleaseChecker(UpdateStatusResponse{CurrentVersion: "1.0.0", Source: "test", Status: "ok"}),
+	}
+
+	response := wp.readinessSnapshot(context.Background())
+	if response.Healthy {
+		t.Fatal("expected readiness to be unhealthy when config path is missing")
+	}
+	if response.BlockingCount == 0 {
+		t.Fatal("expected at least one blocking check")
+	}
+
+	check, ok := readinessCheckByKey(response.Checks, "config_path")
+	if !ok {
+		t.Fatal("expected config_path readiness check")
+	}
+	if check.Severity != ReadinessSeverityBlocking {
+		t.Fatalf("expected config_path to be blocking, got %q", check.Severity)
+	}
+	if status, _ := check.Facts["status"].(string); status != "missing" {
+		t.Fatalf("expected missing config-path status, got %#v", check.Facts["status"])
+	}
+}
+
+func TestWebPanelReadinessSnapshotSummarizesConfiguredState(t *testing.T) {
+	t.Parallel()
+
+	wp, _ := newTestControlPlaneWebPanel(t)
+	defer wp.subManager.Stop()
+
+	configPath := wp.config.ConfigPath
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(raw, &config); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	config["api"] = map[string]interface{}{
+		"tag":      "api",
+		"listen":   "127.0.0.1:10085",
+		"services": []string{"HandlerService", "StatsService", "LoggerService", "RoutingService", "ObservatoryService"},
+	}
+	config["stats"] = map[string]interface{}{}
+	config["policy"] = map[string]interface{}{
+		"system": map[string]interface{}{
+			"statsInboundUplink":    true,
+			"statsInboundDownlink":  true,
+			"statsOutboundUplink":   true,
+			"statsOutboundDownlink": true,
+		},
+	}
+
+	updatedRaw, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, updatedRaw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	now := time.Now()
+	wp.subManager.mu.Lock()
+	wp.subManager.started = true
+	wp.subManager.dispatcherAvailable = true
+	wp.subManager.state.Subscriptions = []SubscriptionRecord{
+		{
+			ID:         "sub-1",
+			SourceType: SubscriptionSourceURL,
+			URL:        "https://example.com/sub",
+			Remark:     "test",
+		},
+	}
+	wp.subManager.state.ValidationConfig.MinActiveNodes = 1
+	wp.subManager.state.Nodes = []NodeRecord{
+		testTransparentNodeRecord(t, "ready-node", "vmess", &now, 90, 0),
+	}
+	wp.subManager.prober = &NodeProber{
+		probeURL: "https://www.gstatic.com/generate_204",
+		interval: 45 * time.Second,
+		tags: map[string]struct{}{
+			"pool_ready-node": {},
+		},
+		running: true,
+	}
+	wp.subManager.mu.Unlock()
+	wp.releaseChecker = cachedReleaseChecker(UpdateStatusResponse{
+		CurrentVersion:  "1.0.0",
+		LatestVersion:   "1.0.0",
+		Source:          "test",
+		Status:          "ok",
+		UpdateAvailable: false,
+	})
+
+	response := wp.readinessSnapshot(context.Background())
+	if response.BlockingCount != 0 {
+		t.Fatalf("expected no blocking checks, got %d", response.BlockingCount)
+	}
+
+	configSections, ok := readinessCheckByKey(response.Checks, "config_sections")
+	if !ok {
+		t.Fatal("expected config_sections check")
+	}
+	if configSections.Severity != ReadinessSeverityOK {
+		t.Fatalf("expected config sections to be ok, got %q", configSections.Severity)
+	}
+
+	probing, ok := readinessCheckByKey(response.Checks, "probing")
+	if !ok {
+		t.Fatal("expected probing check")
+	}
+	if probing.Severity != ReadinessSeverityOK {
+		t.Fatalf("expected probing check to be ok, got %q", probing.Severity)
+	}
+	if running, _ := probing.Facts["running"].(bool); !running {
+		t.Fatalf("expected probing to be running, got %#v", probing.Facts["running"])
+	}
+
+	subscriptions, ok := readinessCheckByKey(response.Checks, "subscriptions")
+	if !ok {
+		t.Fatal("expected subscriptions check")
+	}
+	if subscriptions.Severity != ReadinessSeverityOK {
+		t.Fatalf("expected subscriptions check to be ok, got %q", subscriptions.Severity)
+	}
+}
+
+func cachedReleaseChecker(status UpdateStatusResponse) *releaseChecker {
+	now := time.Date(2026, 4, 4, 4, 0, 0, 0, time.UTC)
+	return &releaseChecker{
+		source:   status.Source,
+		cacheTTL: time.Hour,
+		now:      func() time.Time { return now },
+		cached:   &status,
+		cachedAt: now,
+	}
+}

--- a/app/webpanel/subscription_manager.go
+++ b/app/webpanel/subscription_manager.go
@@ -234,6 +234,8 @@ type SubscriptionManager struct {
 	saveDelay           time.Duration
 	onPoolHealthChange  func(PoolHealthSummary)
 	bgWG                sync.WaitGroup
+	started             bool
+	dispatcherAvailable bool
 }
 
 const (
@@ -293,6 +295,8 @@ func (sm *SubscriptionManager) Start() error {
 			tags = append(tags, n.OutboundTag)
 		}
 	}
+	sm.started = true
+	sm.dispatcherAvailable = dispatcher != nil
 	sm.mu.Unlock()
 
 	if normalized {
@@ -337,6 +341,10 @@ func (sm *SubscriptionManager) Stop() {
 	default:
 		close(sm.stopCh)
 	}
+	sm.mu.Lock()
+	sm.started = false
+	sm.dispatcherAvailable = false
+	sm.mu.Unlock()
 	if sm.prober != nil {
 		sm.prober.Stop()
 	}
@@ -598,6 +606,39 @@ func (sm *SubscriptionManager) GetValidationConfig() ValidationConfig {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
 	return sm.state.ValidationConfig
+}
+
+type SubscriptionManagerReadinessSnapshot struct {
+	Started             bool               `json:"started"`
+	DispatcherAvailable bool               `json:"dispatcherAvailable"`
+	SubscriptionCount   int                `json:"subscriptionCount"`
+	NodeCount           int                `json:"nodeCount"`
+	ProbeURL            string             `json:"probeUrl"`
+	ProbeIntervalSec    int                `json:"probeIntervalSec"`
+	PoolSummary         NodePoolSummary    `json:"poolSummary"`
+	Prober              NodeProberSnapshot `json:"prober"`
+}
+
+func (sm *SubscriptionManager) ReadinessSnapshot() SubscriptionManagerReadinessSnapshot {
+	sm.mu.RLock()
+	cfg := sm.state.ValidationConfig
+	prober := sm.prober
+	snapshot := SubscriptionManagerReadinessSnapshot{
+		Started:             sm.started,
+		DispatcherAvailable: sm.dispatcherAvailable,
+		SubscriptionCount:   len(sm.state.Subscriptions),
+		NodeCount:           len(sm.state.Nodes),
+		ProbeURL:            cfg.ProbeURL,
+		ProbeIntervalSec:    cfg.ProbeIntervalSec,
+		PoolSummary:         sm.poolSummaryLocked(),
+	}
+	sm.mu.RUnlock()
+
+	if prober != nil {
+		snapshot.Prober = prober.Snapshot()
+	}
+
+	return snapshot
 }
 
 func (sm *SubscriptionManager) UpdateValidationConfig(cfg ValidationConfig) {

--- a/app/webpanel/webpanel.go
+++ b/app/webpanel/webpanel.go
@@ -190,6 +190,7 @@ func (wp *WebPanel) registerRoutes(mux *http.ServeMux) {
 	// Stats
 	mux.HandleFunc("/api/v1/sys/stats", wp.authMiddleware(wp.handleSysStats))
 	mux.HandleFunc("/api/v1/sys/update", wp.authMiddleware(wp.handleUpdateStatus))
+	mux.HandleFunc("/api/v1/readiness", wp.authMiddleware(wp.handleReadiness))
 	mux.HandleFunc("/api/v1/stats/query", wp.authMiddleware(wp.handleQueryStats))
 	mux.HandleFunc("/api/v1/stats/online-users", wp.authMiddleware(wp.handleOnlineUsers))
 	mux.HandleFunc("/api/v1/stats/online-ips", wp.authMiddleware(wp.handleOnlineIPs))

--- a/tests/test_web_smoke.py
+++ b/tests/test_web_smoke.py
@@ -204,6 +204,13 @@ class WebSmokeTest(unittest.TestCase):
         self.assertIn("/assets/index-", html)
 
     def test_login_and_authenticated_api_flow(self) -> None:
+        readiness = self.api_get("/api/v1/readiness")
+        self.assertIn("healthy", readiness)
+        self.assertIn("blockingCount", readiness)
+        self.assertIn("warningCount", readiness)
+        self.assertIn("checks", readiness)
+        self.assertIsInstance(readiness["checks"], list)
+
         subscriptions = self.api_get("/api/v1/subscriptions")
         self.assertIn("subscriptions", subscriptions)
         self.assertIsInstance(subscriptions["subscriptions"], list)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import type {
   NodePoolDashboardResponse,
+  ReadinessResponse,
   SubscriptionCreateRequest,
   SubscriptionUpdateRequest,
   TunEditableSettings,
@@ -49,6 +50,10 @@ export const statsAPI = {
   getOnlineUsers: () => apiClient.get('/stats/online-users') as Promise<any>,
   getOnlineIPs: (email: string) =>
     apiClient.get('/stats/online-ips', { params: { email } }) as Promise<any>
+}
+
+export const readinessAPI = {
+  get: () => apiClient.get('/readiness') as Promise<ReadinessResponse>
 }
 
 export const handlerAPI = {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -25,6 +25,26 @@ export interface UpdateStatusResponse {
   stale: boolean
 }
 
+export type ReadinessSeverity = 'ok' | 'warning' | 'blocking'
+export type ReadinessArea = 'config' | 'subscriptions' | 'node_pool' | 'tun' | 'runtime' | 'updates'
+export type ReadinessFacts = Record<string, unknown>
+
+export interface ReadinessCheck {
+  key: string
+  area: ReadinessArea
+  severity: ReadinessSeverity
+  actionRoute?: string
+  facts?: ReadinessFacts
+}
+
+export interface ReadinessResponse {
+  healthy: boolean
+  blockingCount: number
+  warningCount: number
+  updatedAt: string
+  checks: ReadinessCheck[]
+}
+
 export interface StatItem {
   name: string
   value: number

--- a/web/src/components/layout/AppShell.vue
+++ b/web/src/components/layout/AppShell.vue
@@ -78,6 +78,7 @@ const currentRoute = computed(() => {
 
 const menuOptions = computed<MenuOption[]>(() => [
   { label: t('nav.dashboard'), key: 'dashboard' },
+  { label: t('nav.readiness'), key: 'readiness' },
   { label: t('nav.inbounds'), key: 'inbounds' },
   { label: t('nav.outbounds'), key: 'outbounds' },
   { label: t('nav.users'), key: 'users' },

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "readiness": "Readiness",
     "inbounds": "Inbounds",
     "outbounds": "Outbounds",
     "users": "Users",
@@ -51,6 +52,8 @@
   },
   "dashboard": {
     "systemInfo": "System Info",
+    "readinessTitle": "Readiness Overview",
+    "openReadiness": "Open Readiness",
     "uptime": "Uptime",
     "version": "Version",
     "currentVersion": "Current Version",
@@ -78,6 +81,118 @@
     "activeOutbounds": "Active Outbounds",
     "realtimeTraffic": "Realtime Traffic",
     "topUsers": "Top Users"
+  },
+  "readiness": {
+    "title": "Readiness Center",
+    "subtitle": "Aggregate config, subscriptions, probing, node pool, TUN, and update state in one place so the blocking issues are obvious first.",
+    "summaryTitle": "Overall State",
+    "goToArea": "Open Area",
+    "lastUpdated": "Last Refreshed",
+    "noChecks": "No checks available",
+    "severity": {
+      "ok": "OK",
+      "warning": "Warning",
+      "blocking": "Blocking"
+    },
+    "area": {
+      "config": "Config",
+      "subscriptions": "Subscriptions",
+      "node_pool": "Node Pool",
+      "tun": "Transparent Mode",
+      "runtime": "Runtime",
+      "updates": "Updates"
+    },
+    "cards": {
+      "blocking": "Blocking",
+      "warning": "Warnings",
+      "checks": "Checks"
+    },
+    "overview": {
+      "healthyBadge": "Ready",
+      "healthyTitle": "No blocking issues found",
+      "healthyBody": "The critical paths are available. Minor reminders may still exist, but they are not blocking the main workflow.",
+      "warningBadge": "Warnings",
+      "warningTitle": "Attention items found",
+      "warningBody": "{count} warning checks need attention before they grow into failures.",
+      "blockingBadge": "Blocked",
+      "blockingTitle": "Blocking issues found",
+      "blockingBody": "{count} blocking checks mean at least one critical path is unavailable right now.",
+      "unavailableBadge": "Not Loaded",
+      "unavailableTitle": "Readiness data is not loaded",
+      "unavailableBody": "The aggregate status could not be fetched yet. Refresh the page or verify the backend endpoint."
+    },
+    "checks": {
+      "unknown": {
+        "summary": "An unknown readiness check was returned."
+      },
+      "configPath": {
+        "title": "Config File Path",
+        "missing": "webpanel.configPath is not configured, so subscriptions, node-pool management, and transparent-mode diagnostics cannot initialize fully.",
+        "notFound": "The config file could not be found: {path}",
+        "invalid": "The config file cannot be read or is not valid JSON: {path}",
+        "ok": "The config file is available: {path}",
+        "pathDetail": "Config path: {path}",
+        "errorDetail": "Error detail: {error}"
+      },
+      "configSections": {
+        "title": "Required Panel Sections",
+        "ok": "The api, stats, and policy sections required by the panel are present.",
+        "unavailable": "The config file itself is unavailable, so the required sections cannot be checked further.",
+        "missingSectionsSummary": "The config is missing core sections required by the panel.",
+        "partialSummary": "The config exists, but some statistics or API service settings are still incomplete.",
+        "missingSections": "Missing sections: {items}",
+        "missingStatsFlags": "Missing stats flags: {items}",
+        "missingServices": "Missing api.services entries: {items}"
+      },
+      "subscriptions": {
+        "title": "Subscriptions and Imports",
+        "unavailable": "The subscription manager is not initialized, so node imports and pool maintenance are unavailable.",
+        "empty": "There are no subscription sources yet, so the pool cannot replenish nodes automatically.",
+        "noNodes": "{subscriptions} subscription source(s) are configured, but no nodes have been imported yet.",
+        "ok": "{subscriptions} subscription source(s) and {nodes} node(s) are loaded.",
+        "poolDetail": "Pool distribution: active {active}, staging {staging}, candidate {candidate}, quarantine {quarantine}, removed {removed}."
+      },
+      "probing": {
+        "title": "Node Prober",
+        "unavailable": "The prober dependencies are unavailable, so real fail-rate and latency signals cannot be collected.",
+        "notStarted": "The subscription manager has not entered its probing loop yet.",
+        "dispatcherUnavailable": "The Xray routing dispatcher is unavailable, so node probing is disabled.",
+        "idle": "The prober is configured, but there are no probeable node tags right now.",
+        "stopped": "The prober has configuration, but it is not currently running.",
+        "running": "The prober is running and checks {tagCount} node tag(s) every {intervalSec} seconds.",
+        "configDetail": "Probe URL: {probeUrl}; interval: {intervalSec}s; tracked tags: {tagCount}."
+      },
+      "nodePool": {
+        "title": "Node Pool Health",
+        "unavailable": "The node pool is currently unavailable.",
+        "empty": "The node pool does not contain any nodes yet.",
+        "belowMinimum": "The active pool has only {active} node(s), below the minimum of {minimum}.",
+        "ok": "The active pool has {active} node(s), meeting the minimum of {minimum}.",
+        "distributionDetail": "Pool distribution: active {active}, candidate {candidate}, staging {staging}, quarantine {quarantine}, removed {removed}."
+      },
+      "tun": {
+        "title": "Transparent Mode / TUN",
+        "unavailable": "The transparent-mode manager is not initialized.",
+        "degraded": "Transparent mode is degraded or in an error state. Fix it before enabling it again.",
+        "warning": "Transparent mode has warnings. Repair privilege or helper issues before enabling it.",
+        "running": "Transparent mode is enabled.",
+        "stopped": "Transparent mode is disabled.",
+        "messageDetail": "Status message: {message}",
+        "helperMissingDetail": "The helper script is missing, so transparent-mode switching cannot run.",
+        "privilegeRecommendedDetail": "Reinstalling or repairing the privilege helper is recommended.",
+        "machineStateDetail": "Machine state: {state}"
+      },
+      "updates": {
+        "title": "Release Check",
+        "unavailable": "The release checker is currently unavailable.",
+        "error": "The latest release check failed.",
+        "stale": "The page is showing cached release data because the latest refresh did not succeed.",
+        "updateAvailable": "Current version {currentVersion}; newer version {latestVersion} is available.",
+        "ok": "Current version {currentVersion} is up to date based on the latest known release state.",
+        "sourceDetail": "Release source: {source}",
+        "messageDetail": "Extra message: {message}"
+      }
+    }
   },
   "inbounds": {
     "title": "Inbound Management",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -38,6 +38,7 @@
   },
   "nav": {
     "dashboard": "仪表盘",
+    "readiness": "就绪中心",
     "inbounds": "入站管理",
     "outbounds": "出站管理",
     "users": "用户管理",
@@ -51,6 +52,8 @@
   },
   "dashboard": {
     "systemInfo": "系统信息",
+    "readinessTitle": "就绪概览",
+    "openReadiness": "打开就绪中心",
     "uptime": "运行时间",
     "version": "版本",
     "currentVersion": "当前版本",
@@ -78,6 +81,118 @@
     "activeOutbounds": "活跃出站",
     "realtimeTraffic": "实时流量",
     "topUsers": "流量排行"
+  },
+  "readiness": {
+    "title": "就绪中心",
+    "subtitle": "把配置、订阅、探测、节点池、TUN 与更新状态集中展示，优先告诉你哪里会真正影响系统可用性。",
+    "summaryTitle": "总体状态",
+    "goToArea": "前往处理",
+    "lastUpdated": "最近刷新",
+    "noChecks": "暂无检查项",
+    "severity": {
+      "ok": "正常",
+      "warning": "注意",
+      "blocking": "阻塞"
+    },
+    "area": {
+      "config": "配置",
+      "subscriptions": "订阅",
+      "node_pool": "节点池",
+      "tun": "透明模式",
+      "runtime": "运行态",
+      "updates": "更新"
+    },
+    "cards": {
+      "blocking": "阻塞项",
+      "warning": "告警项",
+      "checks": "检查项"
+    },
+    "overview": {
+      "healthyBadge": "已就绪",
+      "healthyTitle": "没有发现阻塞项",
+      "healthyBody": "当前关键路径都已经具备。即使仍有少量提醒项，也不会阻断主流程。",
+      "warningBadge": "有提醒",
+      "warningTitle": "存在需要关注的提醒",
+      "warningBody": "发现 {count} 个提醒项，建议尽快处理，避免后续演变成故障。",
+      "blockingBadge": "有阻塞",
+      "blockingTitle": "存在阻塞问题",
+      "blockingBody": "发现 {count} 个阻塞项，至少有一条关键路径目前不可用。",
+      "unavailableBadge": "未加载",
+      "unavailableTitle": "就绪数据暂未加载",
+      "unavailableBody": "无法获取聚合状态，请先刷新页面或检查后端接口。"
+    },
+    "checks": {
+      "unknown": {
+        "summary": "存在未识别的检查项。"
+      },
+      "configPath": {
+        "title": "配置文件路径",
+        "missing": "未配置 webpanel.configPath，订阅、节点池和透明模式相关功能无法完整初始化。",
+        "notFound": "找不到配置文件：{path}",
+        "invalid": "配置文件无法读取或不是有效 JSON：{path}",
+        "ok": "已检测到配置文件：{path}",
+        "pathDetail": "配置路径：{path}",
+        "errorDetail": "错误详情：{error}"
+      },
+      "configSections": {
+        "title": "面板依赖配置段",
+        "ok": "api、stats、policy 等关键配置段已满足面板要求。",
+        "unavailable": "由于配置文件本身不可用，无法继续检查关键配置段。",
+        "missingSectionsSummary": "配置文件缺少面板依赖的核心段，部分功能将无法工作。",
+        "partialSummary": "配置文件主体存在，但仍缺少部分统计或服务配置。",
+        "missingSections": "缺少配置段：{items}",
+        "missingStatsFlags": "缺少统计开关：{items}",
+        "missingServices": "api.services 缺少服务：{items}"
+      },
+      "subscriptions": {
+        "title": "订阅与节点导入",
+        "unavailable": "订阅管理器未初始化，无法导入或维护节点池。",
+        "empty": "还没有任何订阅来源，节点池目前不会自动补充节点。",
+        "noNodes": "已经配置了 {subscriptions} 个订阅来源，但还没有导入到任何节点。",
+        "ok": "已加载 {subscriptions} 个订阅来源，共 {nodes} 个节点。",
+        "poolDetail": "节点分布：活跃 {active}，验证中 {staging}，候选 {candidate}，隔离 {quarantine}，已移除 {removed}。"
+      },
+      "probing": {
+        "title": "节点探测器",
+        "unavailable": "探测器依赖未就绪，当前无法判断节点真实成功率与平均延迟。",
+        "notStarted": "订阅管理器尚未进入探测循环。",
+        "dispatcherUnavailable": "Xray 路由分发器不可用，节点探测已被禁用。",
+        "idle": "探测器已配置，但当前没有可探测的节点标签。",
+        "stopped": "探测器配置存在，但当前没有运行。",
+        "running": "探测器正在运行，当前会按 {intervalSec} 秒周期检测 {tagCount} 个节点标签。",
+        "configDetail": "探测地址：{probeUrl}；探测间隔：{intervalSec} 秒；当前标签数：{tagCount}。"
+      },
+      "nodePool": {
+        "title": "节点池健康",
+        "unavailable": "节点池当前不可用。",
+        "empty": "节点池中还没有任何节点。",
+        "belowMinimum": "活跃池只有 {active} 个节点，低于最小要求 {minimum}。",
+        "ok": "活跃池共有 {active} 个节点，已达到最小要求 {minimum}。",
+        "distributionDetail": "池内分布：活跃 {active}，候选 {candidate}，验证中 {staging}，隔离 {quarantine}，已移除 {removed}。"
+      },
+      "tun": {
+        "title": "透明模式 / TUN",
+        "unavailable": "透明模式管理器未初始化。",
+        "degraded": "透明模式当前处于异常或降级状态，建议先排障再继续启用。",
+        "warning": "透明模式可见告警，启用前建议先修复提权或 helper 问题。",
+        "running": "透明模式当前已启用。",
+        "stopped": "透明模式当前未启用。",
+        "messageDetail": "状态消息：{message}",
+        "helperMissingDetail": "未检测到 helper 脚本，透明模式切换将无法执行。",
+        "privilegeRecommendedDetail": "建议重新安装或修复提权组件。",
+        "machineStateDetail": "机器状态：{state}"
+      },
+      "updates": {
+        "title": "版本更新检查",
+        "unavailable": "更新检查器当前不可用。",
+        "error": "最近一次更新检查失败。",
+        "stale": "当前展示的是缓存的更新信息，最新检查未成功。",
+        "updateAvailable": "当前版本 {currentVersion}，发现新版本 {latestVersion}。",
+        "ok": "当前版本 {currentVersion} 已是已知最新状态。",
+        "sourceDetail": "检查来源：{source}",
+        "messageDetail": "附加消息：{message}"
+      }
+    }
   },
   "inbounds": {
     "title": "入站管理",

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -15,6 +15,7 @@ const routes: RouteRecordRaw[] = [
     children: [
       { path: '', redirect: '/dashboard' },
       { path: 'dashboard', name: 'Dashboard', component: () => import('@/views/Dashboard.vue') },
+      { path: 'readiness', name: 'Readiness', component: () => import('@/views/Readiness.vue') },
       { path: 'inbounds', name: 'Inbounds', component: () => import('@/views/Inbounds.vue') },
       { path: 'outbounds', name: 'Outbounds', component: () => import('@/views/Outbounds.vue') },
       { path: 'users', name: 'Users', component: () => import('@/views/Users.vue') },

--- a/web/src/utils/readiness.ts
+++ b/web/src/utils/readiness.ts
@@ -1,0 +1,342 @@
+import type { ReadinessArea, ReadinessCheck, ReadinessResponse, ReadinessSeverity } from '@/api/types'
+
+type Translate = (key: string, params?: Record<string, unknown>) => string
+type StatusType = 'success' | 'warning' | 'error' | 'info'
+
+export interface ReadinessDescription {
+  title: string
+  summary: string
+  details: string[]
+}
+
+export interface ReadinessOverview {
+  type: StatusType
+  badgeLabel: string
+  title: string
+  description: string
+}
+
+function stringFact(check: ReadinessCheck, key: string): string {
+  const value = check.facts?.[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function numberFact(check: ReadinessCheck, key: string): number {
+  const value = check.facts?.[key]
+  return typeof value === 'number' ? value : 0
+}
+
+function boolFact(check: ReadinessCheck, key: string): boolean {
+  return check.facts?.[key] === true
+}
+
+function stringArrayFact(check: ReadinessCheck, key: string): string[] {
+  const value = check.facts?.[key]
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+}
+
+function joinItems(items: string[]): string {
+  return items.join(', ')
+}
+
+export function readinessSeverityType(severity: ReadinessSeverity): Exclude<StatusType, 'info'> {
+  switch (severity) {
+    case 'blocking':
+      return 'error'
+    case 'warning':
+      return 'warning'
+    default:
+      return 'success'
+  }
+}
+
+export function readinessSeverityLabel(t: Translate, severity: ReadinessSeverity): string {
+  switch (severity) {
+    case 'blocking':
+      return t('readiness.severity.blocking')
+    case 'warning':
+      return t('readiness.severity.warning')
+    default:
+      return t('readiness.severity.ok')
+  }
+}
+
+export function readinessAreaLabel(t: Translate, area: ReadinessArea): string {
+  return t(`readiness.area.${area}`)
+}
+
+export function describeReadinessOverview(t: Translate, readiness: ReadinessResponse | null): ReadinessOverview {
+  if (!readiness) {
+    return {
+      type: 'info',
+      badgeLabel: t('readiness.overview.unavailableBadge'),
+      title: t('readiness.overview.unavailableTitle'),
+      description: t('readiness.overview.unavailableBody')
+    }
+  }
+
+  if (readiness.blockingCount > 0) {
+    return {
+      type: 'error',
+      badgeLabel: t('readiness.overview.blockingBadge'),
+      title: t('readiness.overview.blockingTitle'),
+      description: t('readiness.overview.blockingBody', { count: readiness.blockingCount })
+    }
+  }
+
+  if (readiness.warningCount > 0) {
+    return {
+      type: 'warning',
+      badgeLabel: t('readiness.overview.warningBadge'),
+      title: t('readiness.overview.warningTitle'),
+      description: t('readiness.overview.warningBody', { count: readiness.warningCount })
+    }
+  }
+
+  return {
+    type: 'success',
+    badgeLabel: t('readiness.overview.healthyBadge'),
+    title: t('readiness.overview.healthyTitle'),
+    description: t('readiness.overview.healthyBody')
+  }
+}
+
+export function describeReadinessCheck(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  switch (check.key) {
+    case 'config_path':
+      return describeConfigPath(t, check)
+    case 'config_sections':
+      return describeConfigSections(t, check)
+    case 'subscriptions':
+      return describeSubscriptions(t, check)
+    case 'probing':
+      return describeProbing(t, check)
+    case 'node_pool':
+      return describeNodePool(t, check)
+    case 'tun':
+      return describeTun(t, check)
+    case 'updates':
+      return describeUpdates(t, check)
+    default:
+      return {
+        title: check.key,
+        summary: t('readiness.checks.unknown.summary'),
+        details: []
+      }
+  }
+}
+
+function describeConfigPath(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  const path = stringFact(check, 'path')
+  const status = stringFact(check, 'status')
+  const error = stringFact(check, 'error')
+  const details = path ? [t('readiness.checks.configPath.pathDetail', { path })] : []
+  if (error) {
+    details.push(t('readiness.checks.configPath.errorDetail', { error }))
+  }
+
+  let summary = t('readiness.checks.configPath.ok', { path })
+  if (status === 'missing') {
+    summary = t('readiness.checks.configPath.missing')
+  } else if (status === 'not_found') {
+    summary = t('readiness.checks.configPath.notFound', { path })
+  } else if (status === 'invalid') {
+    summary = t('readiness.checks.configPath.invalid', { path })
+  }
+
+  return {
+    title: t('readiness.checks.configPath.title'),
+    summary,
+    details
+  }
+}
+
+function describeConfigSections(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  const missingSections = stringArrayFact(check, 'missingSections')
+  const missingStatsFlags = stringArrayFact(check, 'missingStatsFlags')
+  const missingServices = stringArrayFact(check, 'missingServices')
+  const status = stringFact(check, 'status')
+  const details: string[] = []
+
+  if (missingSections.length > 0) {
+    details.push(t('readiness.checks.configSections.missingSections', { items: joinItems(missingSections) }))
+  }
+  if (missingStatsFlags.length > 0) {
+    details.push(t('readiness.checks.configSections.missingStatsFlags', { items: joinItems(missingStatsFlags) }))
+  }
+  if (missingServices.length > 0) {
+    details.push(t('readiness.checks.configSections.missingServices', { items: joinItems(missingServices) }))
+  }
+
+  let summary = t('readiness.checks.configSections.ok')
+  if (status === 'unavailable') {
+    summary = t('readiness.checks.configSections.unavailable')
+  } else if (missingSections.length > 0) {
+    summary = t('readiness.checks.configSections.missingSectionsSummary')
+  } else if (missingStatsFlags.length > 0 || missingServices.length > 0) {
+    summary = t('readiness.checks.configSections.partialSummary')
+  }
+
+  return {
+    title: t('readiness.checks.configSections.title'),
+    summary,
+    details
+  }
+}
+
+function describeSubscriptions(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  const status = stringFact(check, 'status')
+  const subscriptionCount = numberFact(check, 'subscriptionCount')
+  const nodeCount = numberFact(check, 'nodeCount')
+  const details = [
+    t('readiness.checks.subscriptions.poolDetail', {
+      subscriptions: subscriptionCount,
+      nodes: nodeCount,
+      active: numberFact(check, 'activeCount'),
+      staging: numberFact(check, 'stagingCount'),
+      candidate: numberFact(check, 'candidateCount'),
+      quarantine: numberFact(check, 'quarantineCount'),
+      removed: numberFact(check, 'removedCount')
+    })
+  ]
+
+  let summary = t('readiness.checks.subscriptions.ok', { subscriptions: subscriptionCount, nodes: nodeCount })
+  if (status === 'unavailable') {
+    summary = t('readiness.checks.subscriptions.unavailable')
+  } else if (status === 'empty') {
+    summary = t('readiness.checks.subscriptions.empty')
+  } else if (status === 'no_nodes') {
+    summary = t('readiness.checks.subscriptions.noNodes', { subscriptions: subscriptionCount })
+  }
+
+  return {
+    title: t('readiness.checks.subscriptions.title'),
+    summary,
+    details
+  }
+}
+
+function describeProbing(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  const status = stringFact(check, 'status')
+  const probeUrl = stringFact(check, 'probeUrl')
+  const intervalSec = numberFact(check, 'probeIntervalSec')
+  const tagCount = numberFact(check, 'tagCount')
+  const details = [t('readiness.checks.probing.configDetail', { probeUrl, intervalSec, tagCount })]
+
+  let summary = t('readiness.checks.probing.running', { tagCount, intervalSec })
+  if (status === 'unavailable') {
+    summary = t('readiness.checks.probing.unavailable')
+  } else if (status === 'not_started') {
+    summary = t('readiness.checks.probing.notStarted')
+  } else if (status === 'dispatcher_unavailable') {
+    summary = t('readiness.checks.probing.dispatcherUnavailable')
+  } else if (status === 'idle') {
+    summary = t('readiness.checks.probing.idle')
+  } else if (status === 'stopped') {
+    summary = t('readiness.checks.probing.stopped')
+  }
+
+  return {
+    title: t('readiness.checks.probing.title'),
+    summary,
+    details
+  }
+}
+
+function describeNodePool(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  const status = stringFact(check, 'status')
+  const activeCount = numberFact(check, 'activeCount')
+  const minActiveNodes = numberFact(check, 'minActiveNodes')
+  const details = [
+    t('readiness.checks.nodePool.distributionDetail', {
+      active: activeCount,
+      candidate: numberFact(check, 'candidateCount'),
+      staging: numberFact(check, 'stagingCount'),
+      quarantine: numberFact(check, 'quarantineCount'),
+      removed: numberFact(check, 'removedCount')
+    })
+  ]
+
+  let summary = t('readiness.checks.nodePool.ok', { active: activeCount, minimum: minActiveNodes })
+  if (status === 'unavailable') {
+    summary = t('readiness.checks.nodePool.unavailable')
+  } else if (status === 'empty') {
+    summary = t('readiness.checks.nodePool.empty')
+  } else if (status === 'below_minimum') {
+    summary = t('readiness.checks.nodePool.belowMinimum', { active: activeCount, minimum: minActiveNodes })
+  }
+
+  return {
+    title: t('readiness.checks.nodePool.title'),
+    summary,
+    details
+  }
+}
+
+function describeTun(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  const status = stringFact(check, 'status')
+  const message = stringFact(check, 'message')
+  const details: string[] = []
+
+  if (message) {
+    details.push(t('readiness.checks.tun.messageDetail', { message }))
+  }
+  if (!boolFact(check, 'helperExists')) {
+    details.push(t('readiness.checks.tun.helperMissingDetail'))
+  }
+  if (boolFact(check, 'privilegeInstallRecommended')) {
+    details.push(t('readiness.checks.tun.privilegeRecommendedDetail'))
+  }
+  const machineState = stringFact(check, 'machineState')
+  if (machineState) {
+    details.push(t('readiness.checks.tun.machineStateDetail', { state: machineState }))
+  }
+
+  let summary = boolFact(check, 'running') ? t('readiness.checks.tun.running') : t('readiness.checks.tun.stopped')
+  if (status === 'unavailable') {
+    summary = t('readiness.checks.tun.unavailable')
+  } else if (check.severity === 'blocking') {
+    summary = t('readiness.checks.tun.degraded')
+  } else if (check.severity === 'warning') {
+    summary = t('readiness.checks.tun.warning')
+  }
+
+  return {
+    title: t('readiness.checks.tun.title'),
+    summary,
+    details
+  }
+}
+
+function describeUpdates(t: Translate, check: ReadinessCheck): ReadinessDescription {
+  const status = stringFact(check, 'status')
+  const currentVersion = stringFact(check, 'currentVersion')
+  const latestVersion = stringFact(check, 'latestVersion')
+  const source = stringFact(check, 'source')
+  const message = stringFact(check, 'message')
+  const details: string[] = []
+
+  if (source) {
+    details.push(t('readiness.checks.updates.sourceDetail', { source }))
+  }
+  if (message) {
+    details.push(t('readiness.checks.updates.messageDetail', { message }))
+  }
+
+  let summary = t('readiness.checks.updates.ok', { currentVersion })
+  if (status === 'unavailable') {
+    summary = t('readiness.checks.updates.unavailable')
+  } else if (status === 'error') {
+    summary = t('readiness.checks.updates.error')
+  } else if (status === 'stale') {
+    summary = t('readiness.checks.updates.stale')
+  } else if (boolFact(check, 'updateAvailable')) {
+    summary = t('readiness.checks.updates.updateAvailable', { currentVersion, latestVersion })
+  }
+
+  return {
+    title: t('readiness.checks.updates.title'),
+    summary,
+    details
+  }
+}

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -31,6 +31,43 @@
       </n-gi>
     </n-grid>
 
+    <n-card :title="t('dashboard.readinessTitle')" size="small">
+      <template #header-extra>
+        <n-space align="center" :size="12">
+          <n-tag :type="readinessOverview.type" size="small">
+            {{ readinessOverview.badgeLabel }}
+          </n-tag>
+          <n-button size="small" tertiary @click="router.push('/readiness')">
+            {{ t('dashboard.openReadiness') }}
+          </n-button>
+        </n-space>
+      </template>
+
+      <n-space vertical :size="12">
+        <n-alert :type="readinessOverview.type">
+          {{ readinessOverview.description }}
+        </n-alert>
+
+        <n-grid :cols="3" :x-gap="12" responsive="screen" item-responsive>
+          <n-gi span="3 m:1">
+            <n-statistic :label="t('readiness.cards.blocking')">
+              <template #default>{{ readiness?.blockingCount ?? '-' }}</template>
+            </n-statistic>
+          </n-gi>
+          <n-gi span="3 m:1">
+            <n-statistic :label="t('readiness.cards.warning')">
+              <template #default>{{ readiness?.warningCount ?? '-' }}</template>
+            </n-statistic>
+          </n-gi>
+          <n-gi span="3 m:1">
+            <n-statistic :label="t('readiness.cards.checks')">
+              <template #default>{{ readiness?.checks.length ?? '-' }}</template>
+            </n-statistic>
+          </n-gi>
+        </n-grid>
+      </n-space>
+    </n-card>
+
     <n-card :title="t('dashboard.updateStatusTitle')" size="small">
       <template #header-extra>
         <n-space align="center" :size="12">
@@ -108,6 +145,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
 import {
   NSpace,
   NGrid,
@@ -128,13 +166,15 @@ import { CanvasRenderer } from 'echarts/renderers'
 import { LineChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/components'
 import { useI18n } from 'vue-i18n'
-import { statsAPI } from '@/api/client'
-import type { UpdateStatusResponse } from '@/api/types'
+import { readinessAPI, statsAPI } from '@/api/client'
+import type { ReadinessResponse, UpdateStatusResponse } from '@/api/types'
 import { useStatsStore } from '@/stores/stats'
+import { describeReadinessOverview } from '@/utils/readiness'
 import { formatBytes, formatUptime } from '@/utils/format'
 
 use([CanvasRenderer, LineChart, GridComponent, TooltipComponent, LegendComponent])
 
+const router = useRouter()
 const { t } = useI18n()
 const statsStore = useStatsStore()
 
@@ -145,6 +185,7 @@ const totalDownlink = ref(0)
 const trafficHistory = ref<{ time: string; up: number; down: number }[]>([])
 const topUsers = ref<any[]>([])
 const updateStatus = ref<UpdateStatusResponse | null>(null)
+const readiness = ref<ReadinessResponse | null>(null)
 const loadingUpdate = ref(false)
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
@@ -194,6 +235,14 @@ async function fetchData() {
       .slice(0, 10)
   } catch {
     // Ignore polling errors
+  }
+}
+
+async function fetchReadiness() {
+  try {
+    readiness.value = await readinessAPI.get()
+  } catch {
+    readiness.value = null
   }
 }
 
@@ -260,6 +309,8 @@ const updateBadge = computed(() => {
   return { type: 'success' as const, label: t('dashboard.upToDate') }
 })
 
+const readinessOverview = computed(() => describeReadinessOverview(t, readiness.value))
+
 function formatDateTime(value?: string) {
   if (!value) return '-'
   const date = new Date(value)
@@ -269,6 +320,7 @@ function formatDateTime(value?: string) {
 
 onMounted(() => {
   fetchData()
+  fetchReadiness()
   fetchUpdateStatus()
   pollTimer = setInterval(fetchData, 5000)
 })

--- a/web/src/views/Readiness.vue
+++ b/web/src/views/Readiness.vue
@@ -1,0 +1,187 @@
+<template>
+  <n-space vertical :size="16">
+    <div>
+      <h2 class="page-title">{{ t('readiness.title') }}</h2>
+      <div class="page-subtitle">{{ t('readiness.subtitle') }}</div>
+    </div>
+
+    <n-card size="small">
+      <template #header>
+        <n-space align="center" :size="12">
+          <span>{{ t('readiness.summaryTitle') }}</span>
+          <n-tag :type="overview.type">{{ overview.badgeLabel }}</n-tag>
+        </n-space>
+      </template>
+      <template #header-extra>
+        <n-button size="small" @click="fetchReadiness" :loading="loading">
+          {{ t('common.refresh') }}
+        </n-button>
+      </template>
+
+      <n-space vertical :size="12">
+        <n-alert :type="overview.type" :title="overview.title">
+          {{ overview.description }}
+        </n-alert>
+
+        <n-alert v-if="loadError" type="error">
+          {{ loadError }}
+        </n-alert>
+
+        <n-grid :cols="3" :x-gap="12" responsive="screen" item-responsive>
+          <n-gi span="3 m:1">
+            <n-statistic :label="t('readiness.cards.blocking')">
+              <template #default>{{ readiness?.blockingCount ?? 0 }}</template>
+            </n-statistic>
+          </n-gi>
+          <n-gi span="3 m:1">
+            <n-statistic :label="t('readiness.cards.warning')">
+              <template #default>{{ readiness?.warningCount ?? 0 }}</template>
+            </n-statistic>
+          </n-gi>
+          <n-gi span="3 m:1">
+            <n-statistic :label="t('readiness.cards.checks')">
+              <template #default>{{ readiness?.checks.length ?? 0 }}</template>
+            </n-statistic>
+          </n-gi>
+        </n-grid>
+
+        <div class="page-subtitle">
+          {{ t('readiness.lastUpdated') }}: {{ formatDateTime(readiness?.updatedAt) }}
+        </div>
+      </n-space>
+    </n-card>
+
+    <n-spin :show="loading">
+      <n-space vertical :size="12">
+        <n-card
+          v-for="item in describedChecks"
+          :key="item.check.key"
+          size="small"
+          embedded
+        >
+          <template #header>
+            <n-space align="center" :size="8">
+              <n-tag :type="readinessSeverityType(item.check.severity)">
+                {{ readinessSeverityLabel(t, item.check.severity) }}
+              </n-tag>
+              <strong>{{ item.description.title }}</strong>
+            </n-space>
+          </template>
+          <template #header-extra>
+            <n-space align="center" :size="8">
+              <n-tag size="small" :bordered="false">
+                {{ readinessAreaLabel(t, item.check.area) }}
+              </n-tag>
+              <n-button
+                v-if="item.check.actionRoute"
+                text
+                type="primary"
+                @click="openAction(item.check.actionRoute)"
+              >
+                {{ t('readiness.goToArea') }}
+              </n-button>
+            </n-space>
+          </template>
+
+          <n-space vertical :size="8">
+            <div>{{ item.description.summary }}</div>
+            <div
+              v-for="detail in item.description.details"
+              :key="detail"
+              class="check-detail"
+            >
+              {{ detail }}
+            </div>
+          </n-space>
+        </n-card>
+
+        <n-empty v-if="!describedChecks.length && !loading" :description="t('readiness.noChecks')" />
+      </n-space>
+    </n-spin>
+  </n-space>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  NAlert,
+  NButton,
+  NCard,
+  NEmpty,
+  NGi,
+  NGrid,
+  NSpace,
+  NSpin,
+  NStatistic,
+  NTag
+} from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { readinessAPI } from '@/api/client'
+import type { ReadinessResponse } from '@/api/types'
+import {
+  describeReadinessCheck,
+  describeReadinessOverview,
+  readinessAreaLabel,
+  readinessSeverityLabel,
+  readinessSeverityType
+} from '@/utils/readiness'
+
+const router = useRouter()
+const { t } = useI18n()
+
+const readiness = ref<ReadinessResponse | null>(null)
+const loading = ref(false)
+const loadError = ref('')
+
+const overview = computed(() => describeReadinessOverview(t, readiness.value))
+const describedChecks = computed(() =>
+  (readiness.value?.checks ?? []).map((check) => ({
+    check,
+    description: describeReadinessCheck(t, check)
+  }))
+)
+
+async function fetchReadiness() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    readiness.value = await readinessAPI.get()
+  } catch (err: any) {
+    loadError.value = err?.error || t('common.error')
+  } finally {
+    loading.value = false
+  }
+}
+
+function openAction(route: string) {
+  router.push(route)
+}
+
+function formatDateTime(value?: string) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+onMounted(() => {
+  fetchReadiness()
+})
+</script>
+
+<style scoped>
+.page-title {
+  margin: 0;
+}
+
+.page-subtitle {
+  margin-top: 6px;
+  color: var(--n-text-color-3);
+}
+
+.check-detail {
+  color: var(--n-text-color-2);
+  font-size: 13px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a consolidated readiness API for config, subscriptions, probing, node pool, TUN, and update checks
- surface readiness status in the dashboard, navigation, and a dedicated Readiness page
- add bilingual readiness copy and smoke/backend coverage for the new diagnostics path

## Verification
- go test ./app/webpanel/...
- python3 tests/test_web_smoke.py
- bash scripts/check.sh

Closes #10