### PR TITLE
feat: support editing and cloning handlers

### DIFF
--- a/app/webpanel/handler_handler.go
+++ b/app/webpanel/handler_handler.go
@@ -7,8 +7,6 @@ import (
 
 	handlerservice "github.com/xtls/xray-core/app/proxyman/command"
 	"github.com/xtls/xray-core/common/serial"
-	core "github.com/xtls/xray-core/core"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // handleInbounds handles GET /api/v1/inbounds (list) and POST /api/v1/inbounds (add).
@@ -45,6 +43,10 @@ func (wp *WebPanel) handleInboundByTag(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch r.Method {
+	case http.MethodGet:
+		wp.getInbound(w, r, tag)
+	case http.MethodPut:
+		wp.updateInbound(w, r, tag)
 	case http.MethodDelete:
 		wp.removeInbound(w, r, tag)
 	default:
@@ -66,9 +68,12 @@ func (wp *WebPanel) listInbounds(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if ib.ReceiverSettings != nil {
+			inbound["receiverType"] = ib.ReceiverSettings.Type
 			inbound["receiverSettings"] = decodeTypedMessage(ib.ReceiverSettings)
 		}
 		if ib.ProxySettings != nil {
+			inbound["protocol"] = messageProtocolLabel(ib.ProxySettings.Type)
+			inbound["proxyType"] = ib.ProxySettings.Type
 			inbound["proxySettings"] = decodeTypedMessage(ib.ProxySettings)
 		}
 
@@ -89,14 +94,14 @@ func (wp *WebPanel) addInbound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var inboundConfig core.InboundHandlerConfig
-	if err := protojson.Unmarshal(req.Inbound, &inboundConfig); err != nil {
+	inboundConfig, err := decodeInboundHandlerConfig(req.Inbound)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid inbound config: "+err.Error())
 		return
 	}
 
-	_, err := wp.grpcClient.Handler().AddInbound(wp.grpcClient.Context(), &handlerservice.AddInboundRequest{
-		Inbound: &inboundConfig,
+	_, err = wp.grpcClient.Handler().AddInbound(wp.grpcClient.Context(), &handlerservice.AddInboundRequest{
+		Inbound: inboundConfig,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "Failed to add inbound: "+err.Error())
@@ -105,6 +110,53 @@ func (wp *WebPanel) addInbound(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, map[string]string{
 		"message": "Inbound added successfully",
+	})
+}
+
+func (wp *WebPanel) getInbound(w http.ResponseWriter, r *http.Request, tag string) {
+	inboundConfig, err := findInboundConfig(wp.grpcClient.Handler(), tag)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	editable, err := editableInboundFromCore(inboundConfig)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to decode inbound config: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"inbound": editable,
+	})
+}
+
+func (wp *WebPanel) updateInbound(w http.ResponseWriter, r *http.Request, tag string) {
+	var req struct {
+		Inbound json.RawMessage `json:"inbound"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+
+	inboundConfig, err := decodeInboundHandlerConfig(req.Inbound)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid inbound config: "+err.Error())
+		return
+	}
+	if inboundConfig.Tag != tag {
+		writeError(w, http.StatusBadRequest, "Inbound tag cannot be changed during edit")
+		return
+	}
+
+	if err := wp.replaceInboundConfig(tag, inboundConfig); err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to update inbound: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"message": "Inbound updated successfully",
 	})
 }
 
@@ -143,6 +195,10 @@ func (wp *WebPanel) handleOutboundByTag(w http.ResponseWriter, r *http.Request) 
 	}
 
 	switch r.Method {
+	case http.MethodGet:
+		wp.getOutbound(w, r, tag)
+	case http.MethodPut:
+		wp.updateOutbound(w, r, tag)
 	case http.MethodDelete:
 		wp.removeOutbound(w, r, tag)
 	default:
@@ -164,10 +220,16 @@ func (wp *WebPanel) listOutbounds(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if ob.SenderSettings != nil {
+			outbound["senderType"] = ob.SenderSettings.Type
 			outbound["senderSettings"] = decodeTypedMessage(ob.SenderSettings)
 		}
 		if ob.ProxySettings != nil {
+			outbound["protocol"] = messageProtocolLabel(ob.ProxySettings.Type)
+			outbound["proxyType"] = ob.ProxySettings.Type
 			outbound["proxySettings"] = decodeTypedMessage(ob.ProxySettings)
+		}
+		if ob.Comment != "" {
+			outbound["comment"] = ob.Comment
 		}
 
 		outbounds = append(outbounds, outbound)
@@ -175,6 +237,24 @@ func (wp *WebPanel) listOutbounds(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"outbounds": outbounds,
+	})
+}
+
+func (wp *WebPanel) getOutbound(w http.ResponseWriter, r *http.Request, tag string) {
+	outboundConfig, err := findOutboundConfig(wp.grpcClient.Handler(), tag)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	editable, err := editableOutboundFromCore(outboundConfig)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to decode outbound config: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"outbound": editable,
 	})
 }
 
@@ -206,6 +286,35 @@ func (wp *WebPanel) addOutbound(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (wp *WebPanel) updateOutbound(w http.ResponseWriter, r *http.Request, tag string) {
+	var req struct {
+		Outbound json.RawMessage `json:"outbound"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+
+	outboundConfig, err := decodeOutboundHandlerConfig(req.Outbound)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid outbound config: "+err.Error())
+		return
+	}
+	if outboundConfig.Tag != tag {
+		writeError(w, http.StatusBadRequest, "Outbound tag cannot be changed during edit")
+		return
+	}
+
+	if err := wp.replaceOutboundConfig(tag, outboundConfig); err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to update outbound: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"message": "Outbound updated successfully",
+	})
+}
+
 func (wp *WebPanel) removeOutbound(w http.ResponseWriter, r *http.Request, tag string) {
 	_, err := wp.grpcClient.Handler().RemoveOutbound(wp.grpcClient.Context(), &handlerservice.RemoveOutboundRequest{
 		Tag: tag,
@@ -224,6 +333,13 @@ func (wp *WebPanel) removeOutbound(w http.ResponseWriter, r *http.Request, tag s
 func decodeTypedMessage(tm *serial.TypedMessage) map[string]interface{} {
 	if tm == nil {
 		return nil
+	}
+	messageType, value, err := encodeJSONTypedMessage(tm)
+	if err == nil {
+		return map[string]interface{}{
+			"type":  messageType,
+			"value": value,
+		}
 	}
 	return map[string]interface{}{
 		"type":  tm.Type,

--- a/app/webpanel/outbound_config.go
+++ b/app/webpanel/outbound_config.go
@@ -179,6 +179,10 @@ type standardBlackholeSettings struct {
 }
 
 func decodeOutboundHandlerConfig(raw json.RawMessage) (*core.OutboundHandlerConfig, error) {
+	if outboundConfig, ok, err := decodeEditableOutboundHandlerConfig(raw); ok || err != nil {
+		return outboundConfig, err
+	}
+
 	var outboundConfig core.OutboundHandlerConfig
 	if err := protojson.Unmarshal(raw, &outboundConfig); err == nil {
 		return &outboundConfig, nil

--- a/app/webpanel/runtime_handler_config.go
+++ b/app/webpanel/runtime_handler_config.go
@@ -1,0 +1,290 @@
+package webpanel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	handlerservice "github.com/xtls/xray-core/app/proxyman/command"
+	"github.com/xtls/xray-core/common/serial"
+	core "github.com/xtls/xray-core/core"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type editableInboundConfig struct {
+	Tag              string          `json:"tag"`
+	ReceiverType     string          `json:"receiverType"`
+	ReceiverSettings json.RawMessage `json:"receiverSettings"`
+	ProxyType        string          `json:"proxyType"`
+	ProxySettings    json.RawMessage `json:"proxySettings"`
+}
+
+type editableOutboundConfig struct {
+	Tag            string          `json:"tag"`
+	SenderType     string          `json:"senderType"`
+	SenderSettings json.RawMessage `json:"senderSettings"`
+	ProxyType      string          `json:"proxyType"`
+	ProxySettings  json.RawMessage `json:"proxySettings"`
+	Expire         int64           `json:"expire,omitempty"`
+	Comment        string          `json:"comment,omitempty"`
+}
+
+func decodeInboundHandlerConfig(raw json.RawMessage) (*core.InboundHandlerConfig, error) {
+	if inboundConfig, ok, err := decodeEditableInboundHandlerConfig(raw); ok || err != nil {
+		return inboundConfig, err
+	}
+
+	var inboundConfig core.InboundHandlerConfig
+	if err := protojson.Unmarshal(raw, &inboundConfig); err == nil && strings.TrimSpace(inboundConfig.Tag) != "" {
+		return &inboundConfig, nil
+	}
+
+	return nil, fmt.Errorf("invalid inbound config")
+}
+
+func decodeEditableOutboundHandlerConfig(raw json.RawMessage) (*core.OutboundHandlerConfig, bool, error) {
+	var outboundConfig editableOutboundConfig
+	if err := json.Unmarshal(raw, &outboundConfig); err != nil {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(outboundConfig.SenderType) == "" && strings.TrimSpace(outboundConfig.ProxyType) == "" {
+		return nil, false, nil
+	}
+
+	decoded, err := outboundConfig.toCore()
+	if err != nil {
+		return nil, true, err
+	}
+
+	return decoded, true, nil
+}
+
+func decodeEditableInboundHandlerConfig(raw json.RawMessage) (*core.InboundHandlerConfig, bool, error) {
+	var inboundConfig editableInboundConfig
+	if err := json.Unmarshal(raw, &inboundConfig); err != nil {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(inboundConfig.ReceiverType) == "" && strings.TrimSpace(inboundConfig.ProxyType) == "" {
+		return nil, false, nil
+	}
+
+	decoded, err := inboundConfig.toCore()
+	if err != nil {
+		return nil, true, err
+	}
+
+	return decoded, true, nil
+}
+
+func editableInboundFromCore(inboundConfig *core.InboundHandlerConfig) (editableInboundConfig, error) {
+	receiverType, receiverSettings, err := encodeJSONTypedMessage(inboundConfig.ReceiverSettings)
+	if err != nil {
+		return editableInboundConfig{}, err
+	}
+	proxyType, proxySettings, err := encodeJSONTypedMessage(inboundConfig.ProxySettings)
+	if err != nil {
+		return editableInboundConfig{}, err
+	}
+
+	return editableInboundConfig{
+		Tag:              inboundConfig.Tag,
+		ReceiverType:     receiverType,
+		ReceiverSettings: receiverSettings,
+		ProxyType:        proxyType,
+		ProxySettings:    proxySettings,
+	}, nil
+}
+
+func editableOutboundFromCore(outboundConfig *core.OutboundHandlerConfig) (editableOutboundConfig, error) {
+	senderType, senderSettings, err := encodeJSONTypedMessage(outboundConfig.SenderSettings)
+	if err != nil {
+		return editableOutboundConfig{}, err
+	}
+	proxyType, proxySettings, err := encodeJSONTypedMessage(outboundConfig.ProxySettings)
+	if err != nil {
+		return editableOutboundConfig{}, err
+	}
+
+	return editableOutboundConfig{
+		Tag:            outboundConfig.Tag,
+		SenderType:     senderType,
+		SenderSettings: senderSettings,
+		ProxyType:      proxyType,
+		ProxySettings:  proxySettings,
+		Expire:         outboundConfig.Expire,
+		Comment:        outboundConfig.Comment,
+	}, nil
+}
+
+func (c editableInboundConfig) toCore() (*core.InboundHandlerConfig, error) {
+	if strings.TrimSpace(c.Tag) == "" {
+		return nil, fmt.Errorf("inbound tag is required")
+	}
+
+	receiverSettings, err := decodeJSONTypedMessage(c.ReceiverType, c.ReceiverSettings)
+	if err != nil {
+		return nil, fmt.Errorf("decode inbound receiver settings: %w", err)
+	}
+	proxySettings, err := decodeJSONTypedMessage(c.ProxyType, c.ProxySettings)
+	if err != nil {
+		return nil, fmt.Errorf("decode inbound proxy settings: %w", err)
+	}
+	if proxySettings == nil {
+		return nil, fmt.Errorf("inbound proxy settings are required")
+	}
+
+	return &core.InboundHandlerConfig{
+		Tag:              c.Tag,
+		ReceiverSettings: receiverSettings,
+		ProxySettings:    proxySettings,
+	}, nil
+}
+
+func (c editableOutboundConfig) toCore() (*core.OutboundHandlerConfig, error) {
+	if strings.TrimSpace(c.Tag) == "" {
+		return nil, fmt.Errorf("outbound tag is required")
+	}
+
+	senderSettings, err := decodeJSONTypedMessage(c.SenderType, c.SenderSettings)
+	if err != nil {
+		return nil, fmt.Errorf("decode outbound sender settings: %w", err)
+	}
+	proxySettings, err := decodeJSONTypedMessage(c.ProxyType, c.ProxySettings)
+	if err != nil {
+		return nil, fmt.Errorf("decode outbound proxy settings: %w", err)
+	}
+	if proxySettings == nil {
+		return nil, fmt.Errorf("outbound proxy settings are required")
+	}
+
+	return &core.OutboundHandlerConfig{
+		Tag:            c.Tag,
+		SenderSettings: senderSettings,
+		ProxySettings:  proxySettings,
+		Expire:         c.Expire,
+		Comment:        c.Comment,
+	}, nil
+}
+
+func encodeJSONTypedMessage(tm *serial.TypedMessage) (string, json.RawMessage, error) {
+	if tm == nil {
+		return "", nil, nil
+	}
+
+	message, err := tm.GetInstance()
+	if err != nil {
+		return "", nil, fmt.Errorf("decode typed message %q: %w", tm.Type, err)
+	}
+
+	raw, err := protojson.Marshal(message)
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal typed message %q: %w", tm.Type, err)
+	}
+	return tm.Type, json.RawMessage(raw), nil
+}
+
+func decodeJSONTypedMessage(messageType string, raw json.RawMessage) (*serial.TypedMessage, error) {
+	cleanType := strings.TrimSpace(messageType)
+	cleanRaw := bytes.TrimSpace(raw)
+	if cleanType == "" {
+		if len(cleanRaw) == 0 || bytes.Equal(cleanRaw, []byte("null")) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("message type is required")
+	}
+
+	instance, err := serial.GetInstance(cleanType)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported message type %q: %w", cleanType, err)
+	}
+
+	protoMessage, ok := instance.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("message type %q is not a protobuf message", cleanType)
+	}
+	if len(cleanRaw) == 0 || bytes.Equal(cleanRaw, []byte("null")) {
+		cleanRaw = []byte("{}")
+	}
+
+	if err := protojson.Unmarshal(cleanRaw, protoMessage); err != nil {
+		return nil, fmt.Errorf("invalid settings for %q: %w", cleanType, err)
+	}
+	return serial.ToTypedMessage(protoMessage), nil
+}
+
+func messageProtocolLabel(messageType string) string {
+	parts := strings.Split(messageType, ".")
+	for i, part := range parts {
+		if part == "proxy" && i+1 < len(parts) {
+			return strings.ToLower(parts[i+1])
+		}
+	}
+	return strings.ToLower(messageType)
+}
+
+func findInboundConfig(handler handlerservice.HandlerServiceClient, tag string) (*core.InboundHandlerConfig, error) {
+	resp, err := handler.ListInbounds(context.Background(), &handlerservice.ListInboundsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("list inbounds: %w", err)
+	}
+	for _, inboundConfig := range resp.Inbounds {
+		if inboundConfig.GetTag() == tag {
+			return proto.Clone(inboundConfig).(*core.InboundHandlerConfig), nil
+		}
+	}
+	return nil, fmt.Errorf("inbound %q not found", tag)
+}
+
+func findOutboundConfig(handler handlerservice.HandlerServiceClient, tag string) (*core.OutboundHandlerConfig, error) {
+	resp, err := handler.ListOutbounds(context.Background(), &handlerservice.ListOutboundsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("list outbounds: %w", err)
+	}
+	for _, outboundConfig := range resp.Outbounds {
+		if outboundConfig.GetTag() == tag {
+			return proto.Clone(outboundConfig).(*core.OutboundHandlerConfig), nil
+		}
+	}
+	return nil, fmt.Errorf("outbound %q not found", tag)
+}
+
+func (wp *WebPanel) replaceInboundConfig(tag string, inboundConfig *core.InboundHandlerConfig) error {
+	currentConfig, err := findInboundConfig(wp.grpcClient.Handler(), tag)
+	if err != nil {
+		return err
+	}
+
+	ctx := wp.grpcClient.Context()
+	if _, err := wp.grpcClient.Handler().RemoveInbound(ctx, &handlerservice.RemoveInboundRequest{Tag: tag}); err != nil {
+		return fmt.Errorf("remove existing inbound: %w", err)
+	}
+	if _, err := wp.grpcClient.Handler().AddInbound(ctx, &handlerservice.AddInboundRequest{Inbound: inboundConfig}); err != nil {
+		if _, rollbackErr := wp.grpcClient.Handler().AddInbound(ctx, &handlerservice.AddInboundRequest{Inbound: currentConfig}); rollbackErr != nil {
+			return fmt.Errorf("apply replacement: %w; rollback failed: %v", err, rollbackErr)
+		}
+		return fmt.Errorf("apply replacement: %w", err)
+	}
+	return nil
+}
+
+func (wp *WebPanel) replaceOutboundConfig(tag string, outboundConfig *core.OutboundHandlerConfig) error {
+	currentConfig, err := findOutboundConfig(wp.grpcClient.Handler(), tag)
+	if err != nil {
+		return err
+	}
+
+	ctx := wp.grpcClient.Context()
+	if _, err := wp.grpcClient.Handler().RemoveOutbound(ctx, &handlerservice.RemoveOutboundRequest{Tag: tag}); err != nil {
+		return fmt.Errorf("remove existing outbound: %w", err)
+	}
+	if _, err := wp.grpcClient.Handler().AddOutbound(ctx, &handlerservice.AddOutboundRequest{Outbound: outboundConfig}); err != nil {
+		if _, rollbackErr := wp.grpcClient.Handler().AddOutbound(ctx, &handlerservice.AddOutboundRequest{Outbound: currentConfig}); rollbackErr != nil {
+			return fmt.Errorf("apply replacement: %w; rollback failed: %v", err, rollbackErr)
+		}
+		return fmt.Errorf("apply replacement: %w", err)
+	}
+	return nil
+}

--- a/tests/test_web_smoke.py
+++ b/tests/test_web_smoke.py
@@ -84,6 +84,7 @@ class WebSmokeTest(unittest.TestCase):
 
         api_port = reserve_port()
         web_port = reserve_port()
+        inbound_port = reserve_port()
         cls.base_url = f"http://127.0.0.1:{web_port}"
 
         config = json.loads(BASE_CONFIG.read_text(encoding="utf-8"))
@@ -91,6 +92,18 @@ class WebSmokeTest(unittest.TestCase):
         config["webpanel"]["listen"] = f"127.0.0.1:{web_port}"
         config["webpanel"]["apiEndpoint"] = f"127.0.0.1:{api_port}"
         config["webpanel"]["configPath"] = str(cls.config_path)
+        config["inbounds"] = [
+            {
+                "tag": "smoke-socks",
+                "listen": "127.0.0.1",
+                "port": inbound_port,
+                "protocol": "socks",
+                "settings": {
+                    "auth": "noauth",
+                    "udp": True,
+                },
+            }
+        ]
         cls.config_path.write_text(json.dumps(config, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
         override_binary = os.environ.get("XRAY_SMOKE_BINARY")
@@ -225,6 +238,82 @@ class WebSmokeTest(unittest.TestCase):
         self.assertIn("routeMode", tun_settings)
         self.assertIn("remoteDns", tun_settings)
         self.assertIsInstance(tun_settings["remoteDns"], list)
+
+    def test_edit_and_clone_inbounds_and_outbounds(self) -> None:
+        clone_inbound_tag = "smoke-socks-copy"
+        clone_outbound_tag = "direct-copy"
+        edited_inbound_port = reserve_port()
+        cloned_inbound_port = reserve_port()
+
+        try:
+            inbound_detail = self.api_get("/api/v1/inbounds/smoke-socks")["inbound"]
+            edited_inbound = json.loads(json.dumps(inbound_detail))
+            edited_range = edited_inbound["receiverSettings"]["portList"]["range"][0]
+            from_key = "From" if "From" in edited_range else "from"
+            to_key = "To" if "To" in edited_range else "to"
+            edited_range[from_key] = edited_inbound_port
+            edited_range[to_key] = edited_inbound_port
+            self.api_json(
+                "PUT",
+                "/api/v1/inbounds/smoke-socks",
+                {
+                    "inbound": edited_inbound,
+                },
+            )
+
+            updated_inbound = self.api_get("/api/v1/inbounds/smoke-socks")["inbound"]
+            updated_port = updated_inbound["receiverSettings"]["portList"]["range"][0]
+            self.assertEqual(updated_port[from_key], edited_inbound_port)
+            self.assertEqual(updated_port[to_key], edited_inbound_port)
+
+            cloned_inbound = json.loads(json.dumps(updated_inbound))
+            cloned_inbound["tag"] = clone_inbound_tag
+            cloned_range = cloned_inbound["receiverSettings"]["portList"]["range"][0]
+            cloned_range[from_key] = cloned_inbound_port
+            cloned_range[to_key] = cloned_inbound_port
+            self.api_json(
+                "POST",
+                "/api/v1/inbounds",
+                {
+                    "inbound": cloned_inbound,
+                },
+            )
+
+            inbounds = self.api_get("/api/v1/inbounds")["inbounds"]
+            self.assertTrue(any(item["tag"] == clone_inbound_tag for item in inbounds))
+
+            outbound_detail = self.api_get("/api/v1/outbounds/direct")["outbound"]
+            edited_outbound = json.loads(json.dumps(outbound_detail))
+            edited_outbound.setdefault("proxySettings", {})
+            edited_outbound["proxySettings"]["domainStrategy"] = "USE_IP4"
+            self.api_json(
+                "PUT",
+                "/api/v1/outbounds/direct",
+                {
+                    "outbound": edited_outbound,
+                },
+            )
+
+            updated_outbound = self.api_get("/api/v1/outbounds/direct")["outbound"]
+            self.assertEqual(updated_outbound["proxySettings"]["domainStrategy"], "USE_IP4")
+
+            cloned_outbound = json.loads(json.dumps(updated_outbound))
+            cloned_outbound["tag"] = clone_outbound_tag
+            self.api_json(
+                "POST",
+                "/api/v1/outbounds",
+                {
+                    "outbound": cloned_outbound,
+                },
+            )
+
+            outbounds = self.api_get("/api/v1/outbounds")["outbounds"]
+            self.assertTrue(any(item["tag"] == clone_outbound_tag for item in outbounds))
+        finally:
+            with contextlib.suppress(Exception):
+                self.api_json("DELETE", f"/api/v1/inbounds/{clone_inbound_tag}")
+            with contextlib.suppress(Exception):
+                self.api_json("DELETE", f"/api/v1/outbounds/{clone_outbound_tag}")
 
     def test_add_subscription_refresh_and_remove_node_observe_api_state_change(self) -> None:
         initial_link = (

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -58,7 +58,10 @@ export const readinessAPI = {
 
 export const handlerAPI = {
   listInbounds: () => apiClient.get('/inbounds') as Promise<any>,
+  getInbound: (tag: string) => apiClient.get(`/inbounds/${encodeURIComponent(tag)}`) as Promise<any>,
   addInbound: (inbound: any) => apiClient.post('/inbounds', { inbound }) as Promise<any>,
+  updateInbound: (tag: string, inbound: any) =>
+    apiClient.put(`/inbounds/${encodeURIComponent(tag)}`, { inbound }) as Promise<any>,
   removeInbound: (tag: string) => apiClient.delete(`/inbounds/${tag}`) as Promise<any>,
   getInboundUsers: (tag: string) => apiClient.get(`/inbounds/${tag}/users`) as Promise<any>,
   addInboundUser: (tag: string, user: any) =>
@@ -66,7 +69,10 @@ export const handlerAPI = {
   removeInboundUser: (tag: string, email: string) =>
     apiClient.delete(`/inbounds/${tag}/users/${email}`) as Promise<any>,
   listOutbounds: () => apiClient.get('/outbounds') as Promise<any>,
+  getOutbound: (tag: string) => apiClient.get(`/outbounds/${encodeURIComponent(tag)}`) as Promise<any>,
   addOutbound: (outbound: any) => apiClient.post('/outbounds', { outbound }) as Promise<any>,
+  updateOutbound: (tag: string, outbound: any) =>
+    apiClient.put(`/outbounds/${encodeURIComponent(tag)}`, { outbound }) as Promise<any>,
   removeOutbound: (tag: string) => apiClient.delete(`/outbounds/${tag}`) as Promise<any>
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -200,11 +200,15 @@
     "protocol": "Protocol",
     "listen": "Listen",
     "port": "Port",
+    "configJson": "Inbound Config (JSON)",
     "userCount": "Users",
     "uplink": "Uplink",
     "downlink": "Downlink",
     "addInbound": "Add Inbound",
     "editInbound": "Edit Inbound",
+    "cloneInbound": "Clone Inbound",
+    "tagRequired": "Tag is required.",
+    "invalidConfig": "Invalid inbound config JSON.",
     "deleteConfirm": "Are you sure to delete this inbound?"
   },
   "outbounds": {
@@ -213,8 +217,12 @@
     "protocol": "Protocol",
     "server": "Server",
     "port": "Port",
+    "configJson": "Outbound Config (JSON)",
     "addOutbound": "Add Outbound",
     "editOutbound": "Edit Outbound",
+    "cloneOutbound": "Clone Outbound",
+    "tagRequired": "Tag is required.",
+    "invalidConfig": "Invalid outbound config JSON.",
     "deleteConfirm": "Are you sure to delete this outbound?"
   },
   "users": {

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -200,11 +200,15 @@
     "protocol": "协议",
     "listen": "监听地址",
     "port": "端口",
+    "configJson": "入站配置（JSON）",
     "userCount": "用户数",
     "uplink": "上行",
     "downlink": "下行",
     "addInbound": "添加入站",
     "editInbound": "编辑入站",
+    "cloneInbound": "克隆入站",
+    "tagRequired": "标签不能为空。",
+    "invalidConfig": "入站配置 JSON 不合法。",
     "deleteConfirm": "确定要删除此入站吗？"
   },
   "outbounds": {
@@ -213,8 +217,12 @@
     "protocol": "协议",
     "server": "服务器",
     "port": "端口",
+    "configJson": "出站配置（JSON）",
     "addOutbound": "添加出站",
     "editOutbound": "编辑出站",
+    "cloneOutbound": "克隆出站",
+    "tagRequired": "标签不能为空。",
+    "invalidConfig": "出站配置 JSON 不合法。",
     "deleteConfirm": "确定要删除此出站吗？"
   },
   "users": {

--- a/web/src/views/Inbounds.vue
+++ b/web/src/views/Inbounds.vue
@@ -2,41 +2,36 @@
   <n-space vertical :size="16">
     <n-space justify="space-between" align="center">
       <h2>{{ t('inbounds.title') }}</h2>
-      <n-button type="primary" @click="showAdd = true">{{ t('inbounds.addInbound') }}</n-button>
+      <n-button type="primary" @click="openAddDialog">{{ t('inbounds.addInbound') }}</n-button>
     </n-space>
 
     <n-data-table :columns="columns" :data="inbounds" :loading="loading" :pagination="{ pageSize: 20 }" />
 
-    <!-- Add/Edit Dialog -->
-    <n-modal v-model:show="showAdd" preset="dialog" :title="t('inbounds.addInbound')" style="width: 600px">
+    <n-modal v-model:show="showDialog" preset="dialog" :title="dialogTitle" style="width: 760px">
       <n-form :model="form" label-placement="left" label-width="auto">
         <n-form-item :label="t('inbounds.tag')">
-          <n-input v-model:value="form.tag" placeholder="my-inbound" />
+          <n-input v-model:value="form.tag" placeholder="my-inbound" :disabled="mode === 'edit'" />
         </n-form-item>
-        <n-form-item :label="t('inbounds.protocol')">
-          <n-select v-model:value="form.protocol" :options="protocolOptions" />
-        </n-form-item>
-        <n-form-item :label="t('inbounds.listen')">
-          <n-input v-model:value="form.listen" placeholder="0.0.0.0" />
-        </n-form-item>
-        <n-form-item :label="t('inbounds.port')">
-          <n-input-number v-model:value="form.port" :min="1" :max="65535" placeholder="443" />
-        </n-form-item>
-        <n-form-item label="Settings (JSON)">
-          <n-input v-model:value="form.settings" type="textarea" :rows="6" placeholder='{"clients": []}' />
+        <n-form-item :label="t('inbounds.configJson')">
+          <n-input
+            v-model:value="form.configJson"
+            type="textarea"
+            :rows="14"
+            :placeholder="inboundConfigPlaceholder"
+          />
         </n-form-item>
       </n-form>
       <template #action>
-        <n-button @click="showAdd = false">{{ t('common.cancel') }}</n-button>
-        <n-button type="primary" :loading="saving" @click="handleAdd">{{ t('common.confirm') }}</n-button>
+        <n-button @click="showDialog = false">{{ t('common.cancel') }}</n-button>
+        <n-button type="primary" :loading="saving" @click="handleSubmit">{{ t('common.confirm') }}</n-button>
       </template>
     </n-modal>
   </n-space>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, h } from 'vue'
-import { NSpace, NButton, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NPopconfirm, useMessage, type DataTableColumns } from 'naive-ui'
+import { computed, h, onMounted, ref } from 'vue'
+import { NSpace, NButton, NDataTable, NModal, NForm, NFormItem, NInput, NPopconfirm, useMessage, type DataTableColumns } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { handlerAPI } from '@/api/client'
 
@@ -45,28 +40,29 @@ const message = useMessage()
 
 const inbounds = ref<any[]>([])
 const loading = ref(false)
-const showAdd = ref(false)
 const saving = ref(false)
+const showDialog = ref(false)
+const mode = ref<'add' | 'edit' | 'clone'>('add')
+const editingTag = ref('')
 
 const form = ref({
   tag: '',
-  protocol: 'vless',
-  listen: '0.0.0.0',
-  port: 443,
-  settings: '{}'
+  configJson: '{}'
 })
 
-const protocolOptions = [
-  { label: 'VLESS', value: 'vless' },
-  { label: 'VMess', value: 'vmess' },
-  { label: 'Trojan', value: 'trojan' },
-  { label: 'Shadowsocks', value: 'shadowsocks' },
-  { label: 'SOCKS', value: 'socks' },
-  { label: 'HTTP', value: 'http' },
-  { label: 'Dokodemo-door', value: 'dokodemo-door' },
-  { label: 'Hysteria', value: 'hysteria' },
-  { label: 'WireGuard', value: 'wireguard' }
-]
+const inboundConfigPlaceholder = `{
+  "tag": "my-inbound",
+  "receiverType": "xray.app.proxyman.ReceiverConfig",
+  "receiverSettings": {},
+  "proxyType": "xray.proxy.vless.inbound.Config",
+  "proxySettings": {}
+}`
+
+const dialogTitle = computed(() => {
+  if (mode.value === 'edit') return t('inbounds.editInbound')
+  if (mode.value === 'clone') return t('inbounds.cloneInbound')
+  return t('inbounds.addInbound')
+})
 
 const columns: DataTableColumns = [
   { title: t('inbounds.tag'), key: 'tag' },
@@ -76,6 +72,8 @@ const columns: DataTableColumns = [
     render(row: any) {
       return h(NSpace, {}, {
         default: () => [
+          h(NButton, { size: 'small', onClick: () => openEditDialog(row.tag) }, { default: () => t('common.edit') }),
+          h(NButton, { size: 'small', onClick: () => openCloneDialog(row.tag) }, { default: () => t('common.clone') }),
           h(NPopconfirm, {
             onPositiveClick: () => handleDelete(row.tag)
           }, {
@@ -87,6 +85,16 @@ const columns: DataTableColumns = [
     }
   }
 ]
+
+function toPrettyJSON(value: any) {
+  return JSON.stringify(value, null, 2)
+}
+
+function normalizeInboundDraft(rawInbound: any, tag: string) {
+  const inbound = rawInbound && typeof rawInbound === 'object' ? { ...rawInbound } : {}
+  inbound.tag = tag
+  return inbound
+}
 
 async function fetchInbounds() {
   loading.value = true
@@ -100,21 +108,78 @@ async function fetchInbounds() {
   }
 }
 
-async function handleAdd() {
-  saving.value = true
+function openAddDialog() {
+  mode.value = 'add'
+  editingTag.value = ''
+  form.value = {
+    tag: '',
+    configJson: '{}'
+  }
+  showDialog.value = true
+}
+
+async function openEditDialog(tag: string) {
+  loading.value = true
   try {
-    await handlerAPI.addInbound({
-      tag: form.value.tag,
-      protocol: form.value.protocol,
-      listen: form.value.listen,
-      port: form.value.port,
-      settings: JSON.parse(form.value.settings)
-    })
-    message.success(t('common.success'))
-    showAdd.value = false
-    fetchInbounds()
+    const data = await handlerAPI.getInbound(tag)
+    const inbound = data?.inbound ?? data
+    mode.value = 'edit'
+    editingTag.value = tag
+    form.value = {
+      tag,
+      configJson: toPrettyJSON(normalizeInboundDraft(inbound, tag))
+    }
+    showDialog.value = true
   } catch (err: any) {
     message.error(err?.error || t('common.error'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function openCloneDialog(tag: string) {
+  loading.value = true
+  try {
+    const cloneTag = `${tag}-copy`
+    const data = await handlerAPI.getInbound(tag)
+    const inbound = data?.inbound ?? data
+    mode.value = 'clone'
+    editingTag.value = ''
+    form.value = {
+      tag: cloneTag,
+      configJson: toPrettyJSON(normalizeInboundDraft(inbound, cloneTag))
+    }
+    showDialog.value = true
+  } catch (err: any) {
+    message.error(err?.error || t('common.error'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleSubmit() {
+  saving.value = true
+  try {
+    const targetTag = mode.value === 'edit' ? editingTag.value : form.value.tag.trim()
+    if (!targetTag) {
+      message.error(t('inbounds.tagRequired'))
+      return
+    }
+
+    const inbound = JSON.parse(form.value.configJson || '{}')
+    inbound.tag = targetTag
+
+    if (mode.value === 'edit') {
+      await handlerAPI.updateInbound(editingTag.value, inbound)
+    } else {
+      await handlerAPI.addInbound(inbound)
+    }
+
+    message.success(t('common.success'))
+    showDialog.value = false
+    await fetchInbounds()
+  } catch (err: any) {
+    message.error(err?.error || t('inbounds.invalidConfig'))
   } finally {
     saving.value = false
   }
@@ -124,7 +189,7 @@ async function handleDelete(tag: string) {
   try {
     await handlerAPI.removeInbound(tag)
     message.success(t('common.success'))
-    fetchInbounds()
+    await fetchInbounds()
   } catch (err: any) {
     message.error(err?.error || t('common.error'))
   }

--- a/web/src/views/Outbounds.vue
+++ b/web/src/views/Outbounds.vue
@@ -2,35 +2,36 @@
   <n-space vertical :size="16">
     <n-space justify="space-between" align="center">
       <h2>{{ t('outbounds.title') }}</h2>
-      <n-button type="primary" @click="showAdd = true">{{ t('outbounds.addOutbound') }}</n-button>
+      <n-button type="primary" @click="openAddDialog">{{ t('outbounds.addOutbound') }}</n-button>
     </n-space>
 
     <n-data-table :columns="columns" :data="outbounds" :loading="loading" :pagination="{ pageSize: 20 }" />
 
-    <!-- Add Dialog -->
-    <n-modal v-model:show="showAdd" preset="dialog" :title="t('outbounds.addOutbound')" style="width: 600px">
+    <n-modal v-model:show="showDialog" preset="dialog" :title="dialogTitle" style="width: 760px">
       <n-form :model="form" label-placement="left" label-width="auto">
         <n-form-item :label="t('outbounds.tag')">
-          <n-input v-model:value="form.tag" placeholder="my-outbound" />
+          <n-input v-model:value="form.tag" placeholder="my-outbound" :disabled="mode === 'edit'" />
         </n-form-item>
-        <n-form-item :label="t('outbounds.protocol')">
-          <n-select v-model:value="form.protocol" :options="protocolOptions" />
-        </n-form-item>
-        <n-form-item label="Settings (JSON)">
-          <n-input v-model:value="form.settings" type="textarea" :rows="6" placeholder='{}' />
+        <n-form-item :label="t('outbounds.configJson')">
+          <n-input
+            v-model:value="form.configJson"
+            type="textarea"
+            :rows="14"
+            :placeholder="outboundConfigPlaceholder"
+          />
         </n-form-item>
       </n-form>
       <template #action>
-        <n-button @click="showAdd = false">{{ t('common.cancel') }}</n-button>
-        <n-button type="primary" :loading="saving" @click="handleAdd">{{ t('common.confirm') }}</n-button>
+        <n-button @click="showDialog = false">{{ t('common.cancel') }}</n-button>
+        <n-button type="primary" :loading="saving" @click="handleSubmit">{{ t('common.confirm') }}</n-button>
       </template>
     </n-modal>
   </n-space>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, h } from 'vue'
-import { NSpace, NButton, NDataTable, NModal, NForm, NFormItem, NInput, NSelect, NPopconfirm, useMessage, type DataTableColumns } from 'naive-ui'
+import { computed, h, onMounted, ref } from 'vue'
+import { NSpace, NButton, NDataTable, NModal, NForm, NFormItem, NInput, NPopconfirm, useMessage, type DataTableColumns } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import { handlerAPI } from '@/api/client'
 
@@ -39,29 +40,29 @@ const message = useMessage()
 
 const outbounds = ref<any[]>([])
 const loading = ref(false)
-const showAdd = ref(false)
 const saving = ref(false)
+const showDialog = ref(false)
+const mode = ref<'add' | 'edit' | 'clone'>('add')
+const editingTag = ref('')
 
 const form = ref({
   tag: '',
-  protocol: 'freedom',
-  settings: '{}'
+  configJson: '{}'
 })
 
-const protocolOptions = [
-  { label: 'Freedom', value: 'freedom' },
-  { label: 'Blackhole', value: 'blackhole' },
-  { label: 'VLESS', value: 'vless' },
-  { label: 'VMess', value: 'vmess' },
-  { label: 'Trojan', value: 'trojan' },
-  { label: 'Shadowsocks', value: 'shadowsocks' },
-  { label: 'SOCKS', value: 'socks' },
-  { label: 'HTTP', value: 'http' },
-  { label: 'DNS', value: 'dns' },
-  { label: 'Loopback', value: 'loopback' },
-  { label: 'WireGuard', value: 'wireguard' },
-  { label: 'Hysteria', value: 'hysteria' }
-]
+const outboundConfigPlaceholder = `{
+  "tag": "my-outbound",
+  "senderType": "xray.app.proxyman.SenderConfig",
+  "senderSettings": {},
+  "proxyType": "xray.proxy.freedom.Config",
+  "proxySettings": {}
+}`
+
+const dialogTitle = computed(() => {
+  if (mode.value === 'edit') return t('outbounds.editOutbound')
+  if (mode.value === 'clone') return t('outbounds.cloneOutbound')
+  return t('outbounds.addOutbound')
+})
 
 const columns: DataTableColumns = [
   { title: t('outbounds.tag'), key: 'tag' },
@@ -71,6 +72,8 @@ const columns: DataTableColumns = [
     render(row: any) {
       return h(NSpace, {}, {
         default: () => [
+          h(NButton, { size: 'small', onClick: () => openEditDialog(row.tag) }, { default: () => t('common.edit') }),
+          h(NButton, { size: 'small', onClick: () => openCloneDialog(row.tag) }, { default: () => t('common.clone') }),
           h(NPopconfirm, {
             onPositiveClick: () => handleDelete(row.tag)
           }, {
@@ -82,6 +85,16 @@ const columns: DataTableColumns = [
     }
   }
 ]
+
+function toPrettyJSON(value: any) {
+  return JSON.stringify(value, null, 2)
+}
+
+function normalizeOutboundDraft(rawOutbound: any, tag: string) {
+  const outbound = rawOutbound && typeof rawOutbound === 'object' ? { ...rawOutbound } : {}
+  outbound.tag = tag
+  return outbound
+}
 
 async function fetchOutbounds() {
   loading.value = true
@@ -95,19 +108,78 @@ async function fetchOutbounds() {
   }
 }
 
-async function handleAdd() {
-  saving.value = true
+function openAddDialog() {
+  mode.value = 'add'
+  editingTag.value = ''
+  form.value = {
+    tag: '',
+    configJson: '{}'
+  }
+  showDialog.value = true
+}
+
+async function openEditDialog(tag: string) {
+  loading.value = true
   try {
-    await handlerAPI.addOutbound({
-      tag: form.value.tag,
-      protocol: form.value.protocol,
-      settings: JSON.parse(form.value.settings)
-    })
-    message.success(t('common.success'))
-    showAdd.value = false
-    fetchOutbounds()
+    const data = await handlerAPI.getOutbound(tag)
+    const outbound = data?.outbound ?? data
+    mode.value = 'edit'
+    editingTag.value = tag
+    form.value = {
+      tag,
+      configJson: toPrettyJSON(normalizeOutboundDraft(outbound, tag))
+    }
+    showDialog.value = true
   } catch (err: any) {
     message.error(err?.error || t('common.error'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function openCloneDialog(tag: string) {
+  loading.value = true
+  try {
+    const cloneTag = `${tag}-copy`
+    const data = await handlerAPI.getOutbound(tag)
+    const outbound = data?.outbound ?? data
+    mode.value = 'clone'
+    editingTag.value = ''
+    form.value = {
+      tag: cloneTag,
+      configJson: toPrettyJSON(normalizeOutboundDraft(outbound, cloneTag))
+    }
+    showDialog.value = true
+  } catch (err: any) {
+    message.error(err?.error || t('common.error'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleSubmit() {
+  saving.value = true
+  try {
+    const targetTag = mode.value === 'edit' ? editingTag.value : form.value.tag.trim()
+    if (!targetTag) {
+      message.error(t('outbounds.tagRequired'))
+      return
+    }
+
+    const outbound = JSON.parse(form.value.configJson || '{}')
+    outbound.tag = targetTag
+
+    if (mode.value === 'edit') {
+      await handlerAPI.updateOutbound(editingTag.value, outbound)
+    } else {
+      await handlerAPI.addOutbound(outbound)
+    }
+
+    message.success(t('common.success'))
+    showDialog.value = false
+    await fetchOutbounds()
+  } catch (err: any) {
+    message.error(err?.error || t('outbounds.invalidConfig'))
   } finally {
     saving.value = false
   }
@@ -117,7 +189,7 @@ async function handleDelete(tag: string) {
   try {
     await handlerAPI.removeOutbound(tag)
     message.success(t('common.success'))
-    fetchOutbounds()
+    await fetchOutbounds()
   } catch (err: any) {
     message.error(err?.error || t('common.error'))
   }


### PR DESCRIPTION
## Summary
- add GET/PUT handler APIs for inbound and outbound configs with safe replace-and-rollback behavior
- expose edit and clone flows in the Inbounds and Outbounds pages using generic JSON config dialogs
- extend the smoke test to cover inbound/outbound edit and clone regressions

## Verification
- go test ./app/webpanel/...
- python3 tests/test_web_smoke.py
- bash scripts/check.sh

Closes #11