### PR TITLE
Add Windows EXE installer packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,3 +286,110 @@ jobs:
           name: Xray-${{ env.ASSET_NAME }}
           path: |
             ./build_assets/*
+
+  package-windows-installer:
+    needs: build
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      INSTALLER_ASSET_NAME: Xray-windows-64-setup
+      RELEASE_TAG_NAME: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+      REF_NAME: ${{ github.ref_name }}
+      IS_TAG_REF: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v6
+
+      - name: Download Windows amd64 build artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: Xray-windows-64
+          path: installer-src
+
+      - name: Validate installer inputs
+        shell: pwsh
+        run: |
+          $required = @(
+            'installer-src\xray.exe',
+            'installer-src\wintun.dll',
+            'installer-src\geoip.dat',
+            'installer-src\geosite.dat',
+            'installer-src\LICENSE',
+            'installer-src\README.md'
+          )
+          $missing = $required | Where-Object { -not (Test-Path $_) }
+          if ($missing.Count -gt 0) {
+            throw "Missing installer input files: $($missing -join ', ')"
+          }
+
+      - name: Resolve installer version
+        shell: pwsh
+        run: |
+          if ('${{ github.event_name }}' -eq 'release' -and $env:RELEASE_TAG_NAME) {
+            $version = $env:RELEASE_TAG_NAME
+          } elseif ($env:IS_TAG_REF -eq 'true') {
+            $version = $env:REF_NAME
+          } else {
+            $shortSha = '${{ github.sha }}'.Substring(0, 7)
+            $version = "dev-${{ github.run_number }}-$shortSha"
+          }
+          "INSTALLER_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - name: Build Windows EXE installer
+        shell: pwsh
+        run: |
+          $sourceDir = (Resolve-Path installer-src).Path
+          $outputDir = Join-Path $PWD 'installer-out'
+          New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) {
+            throw "ISCC.exe not found at $iscc"
+          }
+
+          & $iscc `
+            "/DMyAppVersion=$env:INSTALLER_VERSION" `
+            "/DMySourceDir=$sourceDir" `
+            "/DMyOutputDir=$outputDir" `
+            "/DMyOutputBaseFilename=$env:INSTALLER_ASSET_NAME" `
+            "packaging\windows\xray-installer.iss"
+
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Create installer digests
+        shell: pwsh
+        run: |
+          $installer = Join-Path $PWD "installer-out\$env:INSTALLER_ASSET_NAME.exe"
+          $digestFile = "$installer.dgst"
+          if (Test-Path $digestFile) {
+            Remove-Item $digestFile -Force
+          }
+
+          foreach ($method in @('MD5', 'SHA1', 'SHA256', 'SHA512')) {
+            $hash = (Get-FileHash -Path $installer -Algorithm $method).Hash.ToLower()
+            Add-Content -Path $digestFile -Value "$method($([System.IO.Path]::GetFileName($installer)))= $hash"
+          }
+
+      - name: Upload installer to release
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'release'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./installer-out/${{ env.INSTALLER_ASSET_NAME }}.exe*
+          tag: ${{ github.ref }}
+          file_glob: true
+
+      - name: Upload installer to Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.INSTALLER_ASSET_NAME }}
+          path: |
+            ./installer-out/${{ env.INSTALLER_ASSET_NAME }}.exe
+            ./installer-out/${{ env.INSTALLER_ASSET_NAME }}.exe.dgst

--- a/README.md
+++ b/README.md
@@ -210,6 +210,47 @@ This repository uses a hard-gated change workflow for local work and PRs.
 
 Release packaging workflows in [`.github/workflows/release.yml`](.github/workflows/release.yml) and [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml) are reserved for version tags, published releases, and manual dispatch, so normal PRs stay on the fast validation path.
 
+### Release Matrix
+
+The matrix below describes what the current release workflows produce. It reflects the workflow definitions in [`.github/workflows/release.yml`](.github/workflows/release.yml), [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml), and [`.github/workflows/docker.yml`](.github/workflows/docker.yml). Existing zip examples are based on release `webpanel-v1.2.1`; the Windows installer entry reflects the workflow added on this branch.
+
+#### Binary Packages
+
+| Target | Architectures | Artifact Type | Workflow | Example Asset |
+| --- | --- | --- | --- | --- |
+| Android | `amd64`, `arm64` | `zip` with CLI binary, not an APK | `Build and Release` | `Xray-android-arm64-v8a.zip` |
+| macOS | `amd64`, `arm64` | `zip` with CLI binary | `Build and Release` | `Xray-macos-arm64-v8a.zip` |
+| Windows | `386`, `amd64`, `arm64` | `zip` with CLI binary; `amd64` also ships a direct `exe` installer | `Build and Release` | `Xray-windows-64.zip`, `Xray-windows-64-setup.exe` |
+| Windows 7 | `386`, `amd64` | `zip` with CLI binary | `Build and Release for Windows 7` | `Xray-win7-64.zip` |
+| Linux | `386`, `amd64`, `armv5`, `armv6`, `armv7`, `arm64`, `riscv64`, `loong64`, `mips`, `mipsle`, `mips64`, `mips64le`, `ppc64`, `ppc64le`, `s390x` | `zip` with CLI binary | `Build and Release` | `Xray-linux-64.zip` |
+| FreeBSD | `386`, `amd64`, `armv7`, `arm64` | `zip` with CLI binary | `Build and Release` | `Xray-freebsd-64.zip` |
+| OpenBSD | `386`, `amd64`, `armv7`, `arm64` | `zip` with CLI binary | `Build and Release` | `Xray-openbsd-64.zip` |
+
+Notes:
+- The Linux `mips` and `mipsle` packages also include soft-float binaries inside the same archive.
+- Release archives include checksum sidecars as `.dgst` files.
+- The Windows `exe` installer currently covers the modern `amd64` build only. Windows `386`, Windows `arm64`, and Windows 7 remain zip-only.
+
+#### Container Images
+
+| Target | Architectures | Artifact Type | Workflow |
+| --- | --- | --- | --- |
+| Docker / GHCR | `linux/amd64`, `linux/386`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64/v8`, `linux/ppc64le`, `linux/s390x`, `linux/riscv64`, `linux/loong64` | Multi-arch container image | `Build and Push Docker Image` |
+
+#### Not Covered Yet
+
+| Area | Current Status |
+| --- | --- |
+| Android app delivery | No APK is published. Current Android artifacts are raw binaries in zip archives. |
+| Apple mobile platforms | No iOS, iPadOS, tvOS, or watchOS release artifacts are produced here. |
+| Desktop installers beyond Windows amd64 | No `msi`, `dmg`, `pkg`, `AppImage`, `deb`, or `rpm` package is published. |
+| Windows installer coverage | Only the modern Windows `amd64` build gets a direct `.exe` installer. Windows `386`, Windows `arm64`, and Windows 7 remain zip-only. |
+| Code signing / notarization | No release workflow in this fork currently performs Windows signing or macOS notarization. |
+| Windows container images | Docker publishing currently targets Linux container architectures only. |
+| Extra Android 32-bit builds | No `armeabi-v7a` or `x86` Android release artifact is produced. |
+
+If you need a user-installable desktop or mobile client, treat these artifacts as core binaries rather than finished application packages.
+
 Fresh clones should install the shared hook path once:
 
 ```bash

--- a/packaging/windows/xray-installer.iss
+++ b/packaging/windows/xray-installer.iss
@@ -1,0 +1,47 @@
+#define MyAppName "Xray-core"
+#define MyAppPublisher "laochendeai"
+#define MyAppURL "https://github.com/laochendeai/Xray-core"
+#define MyAppExeName "xray.exe"
+
+#ifndef MyAppVersion
+  #define MyAppVersion "dev"
+#endif
+
+#ifndef MySourceDir
+  #define MySourceDir "."
+#endif
+
+#ifndef MyOutputDir
+  #define MyOutputDir "."
+#endif
+
+#ifndef MyOutputBaseFilename
+  #define MyOutputBaseFilename "Xray-windows-64-setup"
+#endif
+
+[Setup]
+AppId={{F8831BD1-5B00-41F8-8DB1-12C175B0A6DB}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={autopf}\Xray-core
+DisableProgramGroupPage=yes
+LicenseFile={#MySourceDir}\LICENSE
+OutputDir={#MyOutputDir}
+OutputBaseFilename={#MyOutputBaseFilename}
+Compression=lzma2/max
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible and not arm64
+ArchitecturesInstallIn64BitMode=x64compatible and not arm64
+PrivilegesRequired=admin
+UninstallDisplayIcon={app}\{#MyAppExeName}
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "{#MySourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
Closes #22

## Summary

Add a Windows EXE installer packaging step to the release workflow so future releases publish a direct installer for the modern `windows-amd64` build while keeping the existing zip artifacts unchanged.

## Linked Issue

Closes #22

## Scope

- Added `packaging/windows/xray-installer.iss` for Inno Setup based packaging
- Extended `.github/workflows/release.yml` with a dedicated Windows installer job that downloads the `Xray-windows-64` artifact, builds `Xray-windows-64-setup.exe`, generates digests, uploads it as a workflow artifact, and publishes it on release events
- Updated `README.md` release matrix to document installer coverage and remaining gaps
- Did not add MSI packaging
- Did not add code signing
- Did not add installers for Windows 7, `windows-386`, or `windows-arm64`

## Verification

- [x] `bash scripts/check.sh`
- [x] I tested the affected user flow locally

Additional verification:
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/release-win7.yml .github/workflows/ci.yml`
- [x] Confirmed local `pre-push` hook re-ran `bash scripts/check.sh` successfully during `git push`

## Risks

The main risk is release-time packaging on `windows-latest`, because the installer compile path is only exercised in GitHub Actions. This pass intentionally keeps scope narrow by covering only the modern `windows-amd64` installer and leaving MSI, signing, and other Windows architectures for follow-up work.
