### PR TITLE
Keep subscription-missing nodes in place

### DIFF
--- a/app/webpanel/subscription_manager.go
+++ b/app/webpanel/subscription_manager.go
@@ -183,27 +183,28 @@ type SubscriptionUpdateInput struct {
 
 // NodeRecord represents a node in the pool.
 type NodeRecord struct {
-	ID               string            `json:"id"`
-	URI              string            `json:"uri"`
-	Remark           string            `json:"remark"`
-	Protocol         string            `json:"protocol"`
-	Address          string            `json:"address"`
-	Port             int               `json:"port"`
-	OutboundTag      string            `json:"outboundTag"`
-	Status           NodeStatus        `json:"status"`
-	StatusReason     TransitionReason  `json:"statusReason"`
-	SubscriptionID   string            `json:"subscriptionId"`
-	AddedAt          time.Time         `json:"addedAt"`
-	PromotedAt       *time.Time        `json:"promotedAt,omitempty"`
-	StatusUpdatedAt  *time.Time        `json:"statusUpdatedAt,omitempty"`
-	LastEventAt      *time.Time        `json:"lastEventAt,omitempty"`
-	TotalPings       int               `json:"totalPings"`
-	FailedPings      int               `json:"failedPings"`
-	AvgDelayMs       int64             `json:"avgDelayMs"`
-	ConsecutiveFails int               `json:"consecutiveFails"`
-	LastCheckedAt    *time.Time        `json:"lastCheckedAt,omitempty"`
-	Cleanliness      CleanlinessStatus `json:"cleanliness"`
-	BandwidthTier    BandwidthTier     `json:"bandwidthTier"`
+	ID                  string            `json:"id"`
+	URI                 string            `json:"uri"`
+	Remark              string            `json:"remark"`
+	Protocol            string            `json:"protocol"`
+	Address             string            `json:"address"`
+	Port                int               `json:"port"`
+	OutboundTag         string            `json:"outboundTag"`
+	Status              NodeStatus        `json:"status"`
+	StatusReason        TransitionReason  `json:"statusReason"`
+	SubscriptionMissing bool              `json:"subscriptionMissing,omitempty"`
+	SubscriptionID      string            `json:"subscriptionId"`
+	AddedAt             time.Time         `json:"addedAt"`
+	PromotedAt          *time.Time        `json:"promotedAt,omitempty"`
+	StatusUpdatedAt     *time.Time        `json:"statusUpdatedAt,omitempty"`
+	LastEventAt         *time.Time        `json:"lastEventAt,omitempty"`
+	TotalPings          int               `json:"totalPings"`
+	FailedPings         int               `json:"failedPings"`
+	AvgDelayMs          int64             `json:"avgDelayMs"`
+	ConsecutiveFails    int               `json:"consecutiveFails"`
+	LastCheckedAt       *time.Time        `json:"lastCheckedAt,omitempty"`
+	Cleanliness         CleanlinessStatus `json:"cleanliness"`
+	BandwidthTier       BandwidthTier     `json:"bandwidthTier"`
 }
 
 // ValidationConfig holds the criteria for promoting/quarantining nodes.
@@ -528,6 +529,7 @@ func (sm *SubscriptionManager) DeleteSubscription(id string) error {
 		if sm.state.Nodes[i].Status == NodeStatusRemoved {
 			continue
 		}
+		sm.state.Nodes[i].SubscriptionMissing = false
 		if err := sm.applyTransitionLocked(i, NodeStatusRemoved, TransitionReasonSubscriptionDeleted, EventActorSystem, "subscription deleted"); err != nil {
 			return err
 		}
@@ -1022,6 +1024,7 @@ func (sm *SubscriptionManager) refreshSubscriptionLocked(id string) error {
 
 		if idx, exists := existingByID[nodeID]; exists {
 			node := &sm.state.Nodes[idx]
+			wasMarkedMissing := node.SubscriptionMissing || ((node.Status == NodeStatusCandidate || node.Status == NodeStatusRemoved) && node.StatusReason == TransitionReasonSubscriptionMissing)
 			node.URI = uri
 			node.Remark = link.Remark
 			node.Protocol = link.Protocol
@@ -1034,13 +1037,24 @@ func (sm *SubscriptionManager) refreshSubscriptionLocked(id string) error {
 				}
 			}
 			if node.Status == NodeStatusCandidate && node.StatusReason == TransitionReasonSubscriptionMissing {
+				node.SubscriptionMissing = false
 				if err := sm.applyTransitionLocked(idx, NodeStatusStaging, TransitionReasonSubscriptionReintroduced, EventActorSystem, "subscription reintroduced"); err != nil {
+					node.SubscriptionMissing = wasMarkedMissing
 					sm.applyTransitionLocked(idx, NodeStatusCandidate, TransitionReasonSubscriptionMissing, EventActorSystem, err.Error())
 				}
 			}
 			if node.Status == NodeStatusRemoved && node.StatusReason == TransitionReasonSubscriptionMissing {
+				node.SubscriptionMissing = false
 				if err := sm.applyTransitionLocked(idx, NodeStatusStaging, TransitionReasonSubscriptionReintroduced, EventActorSystem, "subscription reintroduced"); err != nil {
+					node.SubscriptionMissing = wasMarkedMissing
 					sm.applyTransitionLocked(idx, NodeStatusRemoved, TransitionReasonSubscriptionMissing, EventActorSystem, err.Error())
+				}
+			}
+			if wasMarkedMissing && node.SubscriptionMissing {
+				if node.StatusReason == TransitionReasonSubscriptionReintroduced {
+					node.SubscriptionMissing = false
+				} else if node.StatusReason != TransitionReasonSubscriptionMissing {
+					sm.setSubscriptionMissingLocked(idx, false, TransitionReasonSubscriptionReintroduced, EventActorSystem, "subscription reintroduced; kept in current pool")
 				}
 			}
 			continue
@@ -1075,15 +1089,10 @@ func (sm *SubscriptionManager) refreshSubscriptionLocked(id string) error {
 		if newNodeIDs[node.ID] {
 			continue
 		}
-		if node.Status == NodeStatusRemoved && node.StatusReason != TransitionReasonSubscriptionMissing {
+		if node.SubscriptionMissing {
 			continue
 		}
-		if node.Status == NodeStatusCandidate && node.StatusReason == TransitionReasonSubscriptionMissing {
-			continue
-		}
-		if err := sm.applyTransitionLocked(i, NodeStatusCandidate, TransitionReasonSubscriptionMissing, EventActorSystem, "node disappeared from upstream subscription; parked in candidate"); err != nil {
-			return err
-		}
+		sm.setSubscriptionMissingLocked(i, true, TransitionReasonSubscriptionMissing, EventActorSystem, "node disappeared from upstream subscription; kept in current pool")
 	}
 
 	for i := range sm.state.Subscriptions {
@@ -1260,7 +1269,7 @@ func (sm *SubscriptionManager) applyTransitionLocked(idx int, nextStatus NodeSta
 	case TransitionReasonProbeQualified, TransitionReasonProbeRequalified, TransitionReasonManualPromote:
 		errors.LogInfo(context.Background(), "node pool: activated node ", node.Remark, " (", node.ID, ")")
 	case TransitionReasonSubscriptionMissing:
-		errors.LogInfo(context.Background(), "node pool: parked missing subscription node in candidate ", node.Remark, " (", node.ID, ")")
+		errors.LogInfo(context.Background(), "node pool: marked missing subscription node ", node.Remark, " (", node.ID, ")")
 	case TransitionReasonManualRestore:
 		errors.LogInfo(context.Background(), "node pool: moved removed node back to candidate ", node.Remark, " (", node.ID, ")")
 	case TransitionReasonManualRemove, TransitionReasonSubscriptionDeleted:
@@ -1268,6 +1277,38 @@ func (sm *SubscriptionManager) applyTransitionLocked(idx int, nextStatus NodeSta
 	}
 
 	return nil
+}
+
+func (sm *SubscriptionManager) setSubscriptionMissingLocked(idx int, missing bool, reason TransitionReason, actor EventActor, details string) {
+	if idx < 0 || idx >= len(sm.state.Nodes) {
+		return
+	}
+
+	node := &sm.state.Nodes[idx]
+	if node.SubscriptionMissing == missing {
+		return
+	}
+
+	now := time.Now()
+	node.SubscriptionMissing = missing
+	node.LastEventAt = &now
+
+	sm.appendNodeEventLocked(NodeEvent{
+		NodeID:   node.ID,
+		Remark:   node.Remark,
+		Status:   node.Status,
+		Reason:   reason,
+		Actor:    actor,
+		At:       now,
+		Details:  details,
+		NodeAddr: fmt.Sprintf("%s:%d", node.Address, node.Port),
+	})
+
+	if missing {
+		errors.LogInfo(context.Background(), "node pool: marked missing subscription node and kept status ", node.Status, " for ", node.Remark, " (", node.ID, ")")
+		return
+	}
+	errors.LogInfo(context.Background(), "node pool: cleared missing-subscription marker for ", node.Remark, " (", node.ID, ")")
 }
 
 func (sm *SubscriptionManager) normalizeProbeStateLocked() bool {
@@ -1836,6 +1877,10 @@ func normalizeNodeRecord(node *NodeRecord, now time.Time) bool {
 		}
 		changed = true
 	}
+	if node.StatusReason == TransitionReasonSubscriptionMissing && !node.SubscriptionMissing {
+		node.SubscriptionMissing = true
+		changed = true
+	}
 	return changed
 }
 
@@ -1886,7 +1931,7 @@ func isAllowedNodeTransition(current, next NodeStatus) bool {
 }
 
 func isCountedSubscriptionNode(node NodeRecord) bool {
-	return node.Status != NodeStatusRemoved && node.StatusReason != TransitionReasonSubscriptionMissing
+	return node.Status != NodeStatusRemoved && !node.SubscriptionMissing && node.StatusReason != TransitionReasonSubscriptionMissing
 }
 
 func probeOutboundTag(nodeID string) string {

--- a/app/webpanel/subscription_manager_test.go
+++ b/app/webpanel/subscription_manager_test.go
@@ -861,7 +861,7 @@ func TestSubscriptionManagerBulkPurgeRemovedDeletesOnlySelectedRemovedNodes(t *t
 	}
 }
 
-func TestSubscriptionManagerRefreshSubscriptionParksMissingNodesInCandidate(t *testing.T) {
+func TestSubscriptionManagerRefreshSubscriptionKeepsMissingNodesInPlace(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
@@ -944,14 +944,21 @@ func TestSubscriptionManagerRefreshSubscriptionParksMissingNodesInCandidate(t *t
 		tagByID[node.ID] = node.OutboundTag
 	}
 
-	if statusByID[missingID] != NodeStatusCandidate {
-		t.Fatalf("expected missing node to move to candidate, got %q", statusByID[missingID])
+	if statusByID[missingID] != NodeStatusStaging {
+		t.Fatalf("expected missing node to stay staging, got %q", statusByID[missingID])
 	}
-	if reasonByID[missingID] != TransitionReasonSubscriptionMissing {
-		t.Fatalf("expected missing node reason to become subscription_missing, got %q", reasonByID[missingID])
+	if reasonByID[missingID] != TransitionReasonSubscriptionNodeDiscovered {
+		t.Fatalf("expected missing node reason to stay subscription_node_discovered, got %q", reasonByID[missingID])
 	}
-	if tagByID[missingID] != "" {
-		t.Fatalf("expected missing node outbound tag to be cleared, got %q", tagByID[missingID])
+	if tagByID[missingID] == "" {
+		t.Fatalf("expected missing node outbound tag to stay registered")
+	}
+	nodeByID := make(map[string]NodeRecord, len(nodes))
+	for _, node := range nodes {
+		nodeByID[node.ID] = node
+	}
+	if !nodeByID[missingID].SubscriptionMissing {
+		t.Fatalf("expected missing node to be marked subscriptionMissing")
 	}
 	if statusByID[liveID] != NodeStatusStaging {
 		t.Fatalf("expected live node to be staged, got %q", statusByID[liveID])
@@ -962,7 +969,7 @@ func TestSubscriptionManagerRefreshSubscriptionParksMissingNodesInCandidate(t *t
 		t.Fatalf("expected 1 subscription, got %d", len(listed))
 	}
 	if listed[0].NodeCount != 1 {
-		t.Fatalf("expected subscription node count 1 after parking missing node, got %d", listed[0].NodeCount)
+		t.Fatalf("expected subscription node count 1 after marking missing node, got %d", listed[0].NodeCount)
 	}
 }
 
@@ -1014,6 +1021,7 @@ func TestSubscriptionManagerRefreshSubscriptionReintroducesCandidateMissingNode(
 	sm.mu.Lock()
 	sm.state.Nodes[0].Status = NodeStatusCandidate
 	sm.state.Nodes[0].StatusReason = TransitionReasonSubscriptionMissing
+	sm.state.Nodes[0].SubscriptionMissing = true
 	sm.state.Nodes[0].OutboundTag = ""
 	now := time.Now().Add(-time.Minute)
 	sm.state.Nodes[0].StatusUpdatedAt = timePtr(now)
@@ -1033,6 +1041,9 @@ func TestSubscriptionManagerRefreshSubscriptionReintroducesCandidateMissingNode(
 	}
 	if nodes[0].StatusReason != TransitionReasonSubscriptionReintroduced {
 		t.Fatalf("expected reintroduced node reason, got %q", nodes[0].StatusReason)
+	}
+	if nodes[0].SubscriptionMissing {
+		t.Fatalf("expected reintroduced node subscriptionMissing to be cleared")
 	}
 	if nodes[0].OutboundTag != probeOutboundTag(nodeID) {
 		t.Fatalf("expected reintroduced node outbound tag %q, got %q", probeOutboundTag(nodeID), nodes[0].OutboundTag)
@@ -1124,6 +1135,108 @@ func TestSubscriptionManagerUpdateSubscriptionMetadataKeepsNodeHistory(t *testin
 	}
 }
 
+func TestSubscriptionManagerRefreshSubscriptionKeepsActiveMissingNodeInPlace(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	handlerStub := &stubHandlerServiceClient{}
+	sm := NewSubscriptionManager(configPath, &GRPCClient{handlerClient: handlerStub}, nil, nil)
+	defer sm.Stop()
+
+	missingURI, err := GenerateShareLink(ShareLinkRequest{
+		Protocol: "vless",
+		Address:  "active-missing.example.com",
+		Port:     443,
+		UUID:     "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Remark:   "active-missing",
+		TLS:      "tls",
+		SNI:      "active-missing.example.com",
+	})
+	if err != nil {
+		t.Fatalf("generate missing share link: %v", err)
+	}
+	liveURI, err := GenerateShareLink(ShareLinkRequest{
+		Protocol: "vless",
+		Address:  "active-live.example.com",
+		Port:     443,
+		UUID:     "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+		Remark:   "active-live",
+		TLS:      "tls",
+		SNI:      "active-live.example.com",
+	})
+	if err != nil {
+		t.Fatalf("generate live share link: %v", err)
+	}
+
+	subID := "sub-active-missing"
+	sm.mu.Lock()
+	sm.state.Subscriptions = []SubscriptionRecord{
+		{
+			ID:         subID,
+			SourceType: SubscriptionSourceManual,
+			Content:    missingURI + "\n" + liveURI,
+			Remark:     "manual sub",
+		},
+	}
+	sm.mu.Unlock()
+
+	if err := sm.RefreshSubscription(subID); err != nil {
+		t.Fatalf("initial refresh subscription: %v", err)
+	}
+
+	nodes := sm.ListNodes("")
+	missingID := ""
+	for _, node := range nodes {
+		if node.Address == "active-missing.example.com" {
+			missingID = node.ID
+			break
+		}
+	}
+	if missingID == "" {
+		t.Fatalf("expected missing node id after initial refresh")
+	}
+
+	sm.mu.Lock()
+	for i := range sm.state.Nodes {
+		if sm.state.Nodes[i].ID != missingID {
+			continue
+		}
+		sm.state.Nodes[i].Status = NodeStatusActive
+		sm.state.Nodes[i].StatusReason = TransitionReasonManualPromote
+		sm.state.Nodes[i].OutboundTag = probeOutboundTag(missingID)
+		break
+	}
+	sm.state.Subscriptions[0].Content = liveURI
+	sm.mu.Unlock()
+
+	if err := sm.RefreshSubscription(subID); err != nil {
+		t.Fatalf("second refresh subscription: %v", err)
+	}
+
+	nodes = sm.ListNodes("")
+	for _, node := range nodes {
+		if node.ID != missingID {
+			continue
+		}
+		if node.Status != NodeStatusActive {
+			t.Fatalf("expected missing active node to stay active, got %q", node.Status)
+		}
+		if node.StatusReason != TransitionReasonManualPromote {
+			t.Fatalf("expected missing active node reason to stay manual_promote, got %q", node.StatusReason)
+		}
+		if !node.SubscriptionMissing {
+			t.Fatalf("expected missing active node to be marked subscriptionMissing")
+		}
+		if node.OutboundTag != probeOutboundTag(missingID) {
+			t.Fatalf("expected missing active node outbound tag %q, got %q", probeOutboundTag(missingID), node.OutboundTag)
+		}
+		return
+	}
+
+	t.Fatalf("missing active node %q not found after refresh", missingID)
+}
+
 func TestSubscriptionManagerUpdateSubscriptionURLReconcilesNodesInPlace(t *testing.T) {
 	t.Parallel()
 
@@ -1194,14 +1307,19 @@ func TestSubscriptionManagerUpdateSubscriptionURLReconcilesNodesInPlace(t *testi
 		addressByID[node.ID] = node.Address
 	}
 
-	if statusByID[originalNodeID] != NodeStatusCandidate {
-		t.Fatalf("expected original node to move to candidate, got %q", statusByID[originalNodeID])
+	if statusByID[originalNodeID] != NodeStatusStaging {
+		t.Fatalf("expected original node to stay staging, got %q", statusByID[originalNodeID])
 	}
-	if reasonByID[originalNodeID] != TransitionReasonSubscriptionMissing {
-		t.Fatalf("expected original node reason subscription_missing, got %q", reasonByID[originalNodeID])
+	if reasonByID[originalNodeID] != TransitionReasonSubscriptionNodeDiscovered {
+		t.Fatalf("expected original node reason subscription_node_discovered, got %q", reasonByID[originalNodeID])
 	}
 	if subscriptionByID[originalNodeID] != sub.ID {
 		t.Fatalf("expected original node subscription ID %q, got %q", sub.ID, subscriptionByID[originalNodeID])
+	}
+	for _, node := range nodes {
+		if node.ID == originalNodeID && !node.SubscriptionMissing {
+			t.Fatalf("expected original node to be marked subscriptionMissing")
+		}
 	}
 
 	replacementCount := 0

--- a/tests/test_web_smoke.py
+++ b/tests/test_web_smoke.py
@@ -435,8 +435,8 @@ class WebSmokeTest(unittest.TestCase):
                     "/api/v1/node-pool",
                     lambda data: any(
                         item["id"] == node_id
-                        and item["status"] == "candidate"
-                        and item["statusReason"] == "subscription_missing"
+                        and item["status"] == "staging"
+                        and item.get("subscriptionMissing") is True
                         for item in data["nodes"]
                     )
                     and any(item["address"] == "smoke-b.example.com" for item in data["nodes"]),
@@ -445,12 +445,13 @@ class WebSmokeTest(unittest.TestCase):
                 replacement_node = next(
                     item for item in refreshed_pool["nodes"] if item["address"] == "smoke-b.example.com"
                 )
-                self.assertEqual(missing_node["status"], "candidate")
-                self.assertEqual(missing_node["statusReason"], "subscription_missing")
+                self.assertEqual(missing_node["status"], "staging")
+                self.assertEqual(missing_node["statusReason"], "subscription_node_discovered")
+                self.assertTrue(missing_node["subscriptionMissing"])
                 self.assertEqual(replacement_node["status"], "staging")
                 self.assertEqual(replacement_node["statusReason"], "subscription_node_discovered")
-                self.assertEqual(refreshed_pool["summary"]["candidateCount"], 1)
-                self.assertEqual(refreshed_pool["summary"]["stagingCount"], 1)
+                self.assertEqual(refreshed_pool["summary"]["candidateCount"], 0)
+                self.assertEqual(refreshed_pool["summary"]["stagingCount"], 2)
 
                 remove_result = self.api_json("POST", f"/api/v1/node-pool/{node_id}/remove")
                 self.assertEqual(remove_result["message"], "Node removed successfully")
@@ -550,8 +551,8 @@ class WebSmokeTest(unittest.TestCase):
                         "/api/v1/node-pool",
                         lambda data: any(
                             item["id"] == original_node_id
-                            and item["status"] == "candidate"
-                            and item["statusReason"] == "subscription_missing"
+                            and item["status"] == "staging"
+                            and item.get("subscriptionMissing") is True
                             for item in data["nodes"]
                         )
                         and any(

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -200,6 +200,7 @@ export interface NodeRecord {
   outboundTag: string
   status: NodeStatus
   statusReason: TransitionReason
+  subscriptionMissing?: boolean
   subscriptionId: string
   addedAt: string
   promotedAt?: string

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -524,7 +524,7 @@
       "avg_delay_desc": "Avg delay high to low"
     },
     "lifecycleGuide": {
-      "candidate": "Waiting to be re-registered, moved back manually from removed, or parked because it disappeared from the subscription; it only starts probing after you send it to validation.",
+      "candidate": "Waiting to be re-registered or moved back manually from removed; it only starts probing after you send it to validation.",
       "staging": "Already in the validation flow. The panel tests fail rate and average latency against the probe URL.",
       "active": "Passed validation and entered the active pool, so it can be used for transparent mode and node selection.",
       "quarantine": "Failed repeated probes or was moved out manually; it is kept out of the active pool for now.",
@@ -559,7 +559,7 @@
       "manual_restore": "Moved manually back to candidate",
       "manual_quarantine": "Moved out of the active pool manually",
       "manual_remove": "Removed manually",
-      "subscription_missing": "Missing from the upstream subscription and parked in candidate",
+      "subscription_missing": "Missing from the upstream subscription",
       "subscription_deleted": "Subscription deleted",
       "subscription_reintroduced": "Reintroduced by the subscription",
       "migration_legacy_demoted": "Migrated from legacy demoted state",
@@ -575,6 +575,7 @@
       "fallback_failed": "Automatic fallback failed",
       "state_load_defaulted": "Machine state file was reset to defaults"
     },
+    "subscriptionMissingFlag": "Subscription Missing",
     "banner": {
       "cleanTitle": "The machine is clean right now",
       "proxiedTitle": "Transparent mode is currently using the node pool",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -524,7 +524,7 @@
       "avg_delay_desc": "按平均延迟从高到低"
     },
     "lifecycleGuide": {
-      "candidate": "等待重新注册、手工从已移除移回，或因订阅中已消失而暂时停放；点击“加入验证池”后才开始探测。",
+      "candidate": "等待重新注册或手工从已移除移回；点击“加入验证池”后才开始探测。",
       "staging": "已进入验证流程，系统会按探测地址测试失败率和平均延迟。",
       "active": "探测达标，进入活跃池，可用于透明模式和节点选择。",
       "quarantine": "连续探测失败或被手动移出活跃池；暂不作为活跃节点使用。",
@@ -559,7 +559,7 @@
       "manual_restore": "手动恢复到候选池",
       "manual_quarantine": "手动移出活跃池",
       "manual_remove": "手动移除",
-      "subscription_missing": "订阅中已消失，已停到候选池",
+      "subscription_missing": "订阅中已消失",
       "subscription_deleted": "订阅已删除",
       "subscription_reintroduced": "订阅重新出现",
       "migration_legacy_demoted": "从旧 demoted 状态迁移",
@@ -575,6 +575,7 @@
       "fallback_failed": "自动回退失败",
       "state_load_defaulted": "机器状态文件损坏，已回退默认值"
     },
+    "subscriptionMissingFlag": "订阅已失联",
     "banner": {
       "cleanTitle": "机器当前是干净状态",
       "proxiedTitle": "透明模式正在使用节点池",

--- a/web/src/views/NodePool.vue
+++ b/web/src/views/NodePool.vue
@@ -231,8 +231,11 @@
               </n-tag>
             </div>
             <div class="node-card-meta">{{ node.address }}:{{ node.port }}</div>
-            <div class="node-card-meta">{{ reasonLabel(node.statusReason) }}</div>
+            <div class="node-card-meta">{{ nodeReasonLabel(node) }}</div>
             <n-space :size="8" wrap>
+              <n-tag v-if="showSubscriptionMissingTag(node)" size="small" type="warning">
+                {{ t('nodePool.subscriptionMissingFlag') }}
+              </n-tag>
               <n-tag size="small" :type="cleanlinessTagType(node.cleanliness)">
                 {{ cleanlinessLabel(node.cleanliness) }}
               </n-tag>
@@ -304,8 +307,11 @@
               </n-tag>
             </div>
             <div class="node-card-meta">{{ node.address }}:{{ node.port }}</div>
-            <div class="node-card-meta">{{ reasonLabel(node.statusReason) }}</div>
+            <div class="node-card-meta">{{ nodeReasonLabel(node) }}</div>
             <n-space :size="8" wrap>
+              <n-tag v-if="showSubscriptionMissingTag(node)" size="small" type="warning">
+                {{ t('nodePool.subscriptionMissingFlag') }}
+              </n-tag>
               <n-tag size="small" :type="cleanlinessTagType(node.cleanliness)">
                 {{ cleanlinessLabel(node.cleanliness) }}
               </n-tag>
@@ -383,8 +389,11 @@
               </n-tag>
             </div>
             <div class="node-card-meta">{{ node.address }}:{{ node.port }}</div>
-            <div class="node-card-meta">{{ reasonLabel(node.statusReason) }}</div>
+            <div class="node-card-meta">{{ nodeReasonLabel(node) }}</div>
             <n-space :size="8" wrap>
+              <n-tag v-if="showSubscriptionMissingTag(node)" size="small" type="warning">
+                {{ t('nodePool.subscriptionMissingFlag') }}
+              </n-tag>
               <n-tag size="small" :type="cleanlinessTagType(node.cleanliness)">
                 {{ cleanlinessLabel(node.cleanliness) }}
               </n-tag>
@@ -462,8 +471,11 @@
               </n-tag>
             </div>
             <div class="node-card-meta">{{ node.address }}:{{ node.port }}</div>
-            <div class="node-card-meta">{{ reasonLabel(node.statusReason) }}</div>
+            <div class="node-card-meta">{{ nodeReasonLabel(node) }}</div>
             <n-space :size="8" wrap>
+              <n-tag v-if="showSubscriptionMissingTag(node)" size="small" type="warning">
+                {{ t('nodePool.subscriptionMissingFlag') }}
+              </n-tag>
               <n-tag size="small" :type="cleanlinessTagType(node.cleanliness)">
                 {{ cleanlinessLabel(node.cleanliness) }}
               </n-tag>
@@ -551,8 +563,13 @@
               </n-tag>
             </div>
             <div class="node-card-meta">{{ node.address }}:{{ node.port }}</div>
-            <div class="node-card-meta">{{ reasonLabel(node.statusReason) }}</div>
+            <div class="node-card-meta">{{ nodeReasonLabel(node) }}</div>
             <div class="node-card-meta">{{ t('nodePool.removedAt') }}: {{ formatDateTime(node.statusUpdatedAt || node.lastEventAt || node.addedAt) || '-' }}</div>
+            <n-space v-if="showSubscriptionMissingTag(node)" :size="8" wrap>
+              <n-tag size="small" type="warning">
+                {{ t('nodePool.subscriptionMissingFlag') }}
+              </n-tag>
+            </n-space>
             <n-space :size="8" class="node-card-actions">
               <n-button size="small" type="primary" @click="handleRestore(node.id)">
                 {{ t('nodePool.restoreNode') }}
@@ -951,6 +968,17 @@ function reasonLabel(reason: TransitionReason | MachineStateReason) {
   return translateCode('nodePool.reason', reason)
 }
 
+function showSubscriptionMissingTag(node: NodeRecord) {
+  return !!node.subscriptionMissing && node.statusReason !== 'subscription_missing'
+}
+
+function nodeReasonLabel(node: NodeRecord) {
+  if (node.subscriptionMissing && node.statusReason === 'subscription_missing') {
+    return reasonLabel('subscription_missing')
+  }
+  return reasonLabel(node.statusReason)
+}
+
 function cleanlinessLabel(cleanliness: CleanlinessStatus) {
   return translateCode('nodePool.cleanliness', cleanliness)
 }
@@ -1122,15 +1150,25 @@ function createColumns(group: 'candidate' | 'staging' | 'active' | 'quarantine' 
     {
       title: () => t('nodePool.address'),
       key: 'address',
-      width: 200,
-      render: (row) => `${row.address}:${row.port}`
+      width: 240,
+      render: (row) => {
+        if (!showSubscriptionMissingTag(row)) {
+          return `${row.address}:${row.port}`
+        }
+        return h(NSpace, { size: 6, align: 'center' }, {
+          default: () => [
+            h('span', `${row.address}:${row.port}`),
+            h(NTag, { size: 'small', type: 'warning' }, { default: () => t('nodePool.subscriptionMissingFlag') })
+          ]
+        })
+      }
     },
     {
       title: () => t('nodePool.reasonLabel'),
       key: 'statusReason',
       width: 200,
       ellipsis: { tooltip: true },
-      render: (row) => reasonLabel(row.statusReason)
+      render: (row) => nodeReasonLabel(row)
     },
     {
       title: () => t('nodePool.avgDelay'),


### PR DESCRIPTION
Closes #24

## Summary

Keep nodes that disappear from an upstream subscription in their current pool instead of auto-moving them into candidate, persist an explicit `subscriptionMissing` marker, surface that marker in the WebPanel, and update backend plus smoke regressions to lock in the new behavior.

## Linked Issue

Closes #24

## Scope

- Added a persisted `subscriptionMissing` marker to node records and changed subscription refresh reconciliation to keep missing nodes in their current pool
- Preserved legacy reintroduction handling for already-parked candidate/removed records while making new refreshes keep active/staging/quarantine/candidate nodes in place
- Updated Node Pool UI and both locales to show the lost marker and removed the old “parked in candidate” wording
- Updated Go tests and `tests/test_web_smoke.py` to match the new rule
- Did not attempt to reconstruct original pools for old records already parked in candidate by the previous implementation

## Verification

- [x] `bash scripts/check.sh`
- [x] I tested the affected user flow locally

Additional verification:
- [x] `go test ./app/webpanel/...`
- [x] `npm --prefix web run test`
- [x] `pre-push` hook re-ran `bash scripts/check.sh` successfully during `git push`

## Risks

Existing legacy records that were already moved into candidate under the old rule cannot be restored to their prior pool automatically because that history was never persisted. The new in-place behavior only applies to future subscription refresh reconciliations.
