### PR TITLE
chore: release webpanel v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Release packaging workflows in [`.github/workflows/release.yml`](.github/workflo
 
 ### Release Matrix
 
-The matrix below describes what the current release workflows produce. It reflects the workflow definitions in [`.github/workflows/release.yml`](.github/workflows/release.yml), [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml), and [`.github/workflows/docker.yml`](.github/workflows/docker.yml). Existing zip examples are based on release `webpanel-v1.2.1`; the Windows installer entry reflects the workflow added on this branch.
+The matrix below describes what the current release workflows produce. It reflects the workflow definitions in [`.github/workflows/release.yml`](.github/workflows/release.yml), [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml), and [`.github/workflows/docker.yml`](.github/workflows/docker.yml). Existing zip examples are based on release `webpanel-v1.2.2`; the Windows installer entry reflects the workflow added on this branch.
 
 #### Binary Packages
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xray-webpanel",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xray-webpanel",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "axios": "^1.7.0",
         "echarts": "^5.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-webpanel",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump WebPanel package metadata to 1.2.2
- refresh the README release-matrix example tag to webpanel-v1.2.2
- keep the repository release workflow aligned before cutting the new release

## Verification
- bash scripts/check.sh

Closes #26