### PR TITLE
fix(webpanel): route protected TUN domains through direct DNS

### DIFF
--- a/app/webpanel/tun_manager.go
+++ b/app/webpanel/tun_manager.go
@@ -1170,19 +1170,31 @@ func buildTunDNSConfig(settings *TunFeatureSettings) map[string]interface{} {
 	servers := make([]interface{}, 0, len(defaultTunChinaDNS)+len(settings.RemoteDNS))
 	hasGeosite := runtimeAssetExists(settings, "geosite.dat")
 	hasGeoip := runtimeAssetExists(settings, "geoip.dat")
+	protectedDomains := uniqStrings(append([]string{}, settings.ProtectDomains...))
 
-	if hasGeosite {
+	if hasGeosite || len(protectedDomains) > 0 {
 		for _, address := range defaultTunChinaDNS {
-			server := map[string]interface{}{
-				"address":      normalizeTunResolverAddress(address),
-				"domains":      []string{"geosite:cn"},
-				"skipFallback": true,
-				"tag":          "dns-cn",
+			if hasGeosite {
+				server := map[string]interface{}{
+					"address":      normalizeTunResolverAddress(address),
+					"domains":      []string{"geosite:cn"},
+					"skipFallback": true,
+					"tag":          "dns-cn",
+				}
+				if hasGeoip {
+					server["expectIPs"] = []string{"geoip:cn"}
+				}
+				servers = append(servers, server)
 			}
-			if hasGeoip {
-				server["expectIPs"] = []string{"geoip:cn"}
+
+			if len(protectedDomains) > 0 {
+				servers = append(servers, map[string]interface{}{
+					"address":      normalizeTunResolverAddress(address),
+					"domains":      protectedDomains,
+					"skipFallback": true,
+					"tag":          "dns-cn",
+				})
 			}
-			servers = append(servers, server)
 		}
 	}
 

--- a/app/webpanel/tun_manager_test.go
+++ b/app/webpanel/tun_manager_test.go
@@ -854,6 +854,7 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 	}
 	hasChinaDNS := false
 	hasRemoteDNS := false
+	hasProtectedDNS := false
 	for _, rawServer := range servers {
 		server, ok := rawServer.(map[string]any)
 		if !ok {
@@ -864,6 +865,16 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 			if server["address"] == "tcp://223.5.5.5" {
 				hasChinaDNS = true
 			}
+			if domains, ok := server["domains"].([]any); ok {
+				for _, rawDomain := range domains {
+					if rawDomain == "full:localhost" {
+						hasProtectedDNS = true
+						if _, exists := server["expectIPs"]; exists {
+							t.Fatalf("expected protected direct-domain DNS entry without geoip expectation, got %#v", server)
+						}
+					}
+				}
+			}
 		case "dns-remote":
 			if server["address"] == "tcp://1.1.1.1" {
 				hasRemoteDNS = true
@@ -872,6 +883,9 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 	}
 	if !hasChinaDNS {
 		t.Fatal("expected china split-dns server in runtime config")
+	}
+	if !hasProtectedDNS {
+		t.Fatal("expected protected direct-domain DNS server in runtime config")
 	}
 	if !hasRemoteDNS {
 		t.Fatal("expected remote split-dns server in runtime config")


### PR DESCRIPTION
Closes #28

## Summary

Mirror `webpanel.tun.protectDomains` into the direct TUN DNS split so protected domains do not resolve through the remote DNS path before being routed direct.

## Linked Issue

Closes #28.

## Scope

- What changed
  - `buildTunDNSConfig` now writes protected direct domains into `dns-cn` entries.
  - Added regression coverage for protected-domain DNS generation.
- What did not change
  - Did not change the broader UDP/443 blocking behavior in transparent TUN.
  - Did not change user-facing UI text.

## Verification

- [x] `bash scripts/check.sh`
- [ ] I tested the affected user flow locally

Relevant output and notes:
- `go test ./app/webpanel -run 'TestBuildTunRuntimeConfig(InjectsDNSOutboundAndSplitRules|BlocksUDP443BeforeTunCatchAllAndAddsBlockOutbound)'`
- `bash scripts/check.sh`
- Also passed the repository pre-push hook, which reruns `bash scripts/check.sh`.
- I did not do a live transparent-TUN toggle on this workstation for the PR checklist; the change is covered by runtime-config generation tests.

## Risks

The main regression surface is TUN split-DNS generation. This change intentionally keeps the existing transport and catch-all routing behavior untouched, including the current UDP/443 block rule.