### PR TITLE
fix: preserve system dns for protected tun domains

### DIFF
--- a/app/webpanel/tun_manager.go
+++ b/app/webpanel/tun_manager.go
@@ -944,6 +944,11 @@ func buildTunRuntimeConfigWithDirectProbeResults(raw []byte, settings *TunFeatur
 			"domain":      settings.ProtectDomains,
 			"outboundTag": "direct",
 		})
+		prependRules = append(prependRules, map[string]interface{}{
+			"type":        "field",
+			"inboundTag":  []string{"dns-direct-local"},
+			"outboundTag": "direct",
+		})
 	}
 	if len(settings.ProtectCIDRs) > 0 {
 		prependRules = append(prependRules, map[string]interface{}{
@@ -1160,34 +1165,32 @@ func buildActivePoolOutbounds(activeNodes []NodeRecord) ([]interface{}, error) {
 }
 
 func buildTunDNSConfig(settings *TunFeatureSettings) map[string]interface{} {
-	servers := make([]interface{}, 0, len(defaultTunChinaDNS)+len(settings.RemoteDNS))
+	servers := make([]interface{}, 0, 1+len(defaultTunChinaDNS)+len(settings.RemoteDNS))
 	hasGeosite := runtimeAssetExists(settings, "geosite.dat")
 	hasGeoip := runtimeAssetExists(settings, "geoip.dat")
 	protectedDomains := uniqStrings(append([]string{}, settings.ProtectDomains...))
 
-	if hasGeosite || len(protectedDomains) > 0 {
-		for _, address := range defaultTunChinaDNS {
-			if hasGeosite {
-				server := map[string]interface{}{
-					"address":      normalizeTunResolverAddress(address),
-					"domains":      []string{"geosite:cn"},
-					"skipFallback": true,
-					"tag":          "dns-cn",
-				}
-				if hasGeoip {
-					server["expectIPs"] = []string{"geoip:cn"}
-				}
-				servers = append(servers, server)
-			}
+	if len(protectedDomains) > 0 {
+		servers = append(servers, map[string]interface{}{
+			"address":      "localhost",
+			"domains":      protectedDomains,
+			"skipFallback": true,
+			"tag":          "dns-direct-local",
+		})
+	}
 
-			if len(protectedDomains) > 0 {
-				servers = append(servers, map[string]interface{}{
-					"address":      normalizeTunResolverAddress(address),
-					"domains":      protectedDomains,
-					"skipFallback": true,
-					"tag":          "dns-cn",
-				})
+	if hasGeosite {
+		for _, address := range defaultTunChinaDNS {
+			server := map[string]interface{}{
+				"address":      normalizeTunResolverAddress(address),
+				"domains":      []string{"geosite:cn"},
+				"skipFallback": true,
+				"tag":          "dns-cn",
 			}
+			if hasGeoip {
+				server["expectIPs"] = []string{"geoip:cn"}
+			}
+			servers = append(servers, server)
 		}
 	}
 

--- a/app/webpanel/tun_manager_test.go
+++ b/app/webpanel/tun_manager_test.go
@@ -854,26 +854,27 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 	}
 	hasChinaDNS := false
 	hasRemoteDNS := false
-	hasProtectedDNS := false
+	hasProtectedLocalDNS := false
 	for _, rawServer := range servers {
 		server, ok := rawServer.(map[string]any)
 		if !ok {
 			continue
 		}
 		switch server["tag"] {
-		case "dns-cn":
-			if server["address"] == "tcp://223.5.5.5" {
-				hasChinaDNS = true
+		case "dns-direct-local":
+			if server["address"] != "localhost" {
+				t.Fatalf("expected protected direct-domain DNS entry to use local system DNS, got %#v", server)
 			}
 			if domains, ok := server["domains"].([]any); ok {
 				for _, rawDomain := range domains {
 					if rawDomain == "full:localhost" {
-						hasProtectedDNS = true
-						if _, exists := server["expectIPs"]; exists {
-							t.Fatalf("expected protected direct-domain DNS entry without geoip expectation, got %#v", server)
-						}
+						hasProtectedLocalDNS = true
 					}
 				}
+			}
+		case "dns-cn":
+			if server["address"] == "tcp://223.5.5.5" {
+				hasChinaDNS = true
 			}
 		case "dns-remote":
 			if server["address"] == "tcp://1.1.1.1" {
@@ -884,8 +885,8 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 	if !hasChinaDNS {
 		t.Fatal("expected china split-dns server in runtime config")
 	}
-	if !hasProtectedDNS {
-		t.Fatal("expected protected direct-domain DNS server in runtime config")
+	if !hasProtectedLocalDNS {
+		t.Fatal("expected protected direct-domain local-system DNS server in runtime config")
 	}
 	if !hasRemoteDNS {
 		t.Fatal("expected remote split-dns server in runtime config")
@@ -902,6 +903,7 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 
 	dnsRuleIndex := -1
 	protectCIDRIndex := -1
+	dnsDirectLocalRouteIndex := -1
 	dnsCNRouteIndex := -1
 	dnsRemoteRouteIndex := -1
 	tunCatchAllIndex := -1
@@ -915,6 +917,9 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 		}
 		if ips, ok := rule["ip"].([]any); ok && len(ips) == 1 && ips[0] == "127.0.0.0/8" && rule["outboundTag"] == "direct" {
 			protectCIDRIndex = index
+		}
+		if inboundTags, ok := rule["inboundTag"].([]any); ok && len(inboundTags) == 1 && inboundTags[0] == "dns-direct-local" && rule["outboundTag"] == "direct" {
+			dnsDirectLocalRouteIndex = index
 		}
 		if inboundTags, ok := rule["inboundTag"].([]any); ok && len(inboundTags) == 1 && inboundTags[0] == "dns-cn" && rule["outboundTag"] == "direct" {
 			dnsCNRouteIndex = index
@@ -932,6 +937,9 @@ func TestBuildTunRuntimeConfigAddsSplitDNSAndRoutesDNSBeforeCatchAll(t *testing.
 	}
 	if protectCIDRIndex == -1 {
 		t.Fatal("expected protect CIDR direct rule")
+	}
+	if dnsDirectLocalRouteIndex == -1 {
+		t.Fatal("expected dns-direct-local direct route")
 	}
 	if dnsCNRouteIndex == -1 {
 		t.Fatal("expected dns-cn direct route")


### PR DESCRIPTION
Closes #32

## Summary

Preserve system DNS affinity for domains listed in `webpanel.tun.protectDomains` when transparent TUN is enabled. Protected direct domains now resolve through the local system resolver instead of being forced onto the built-in China DNS servers, which keeps local ISP/CDN edge selection intact for sites such as `hifly.cc` and `shortvideo-cdn.lingverse.co`.

## Linked Issue

Closes #32.

## Scope

- Changed `app/webpanel/tun_manager.go` so protected direct domains are emitted under a dedicated `dns-direct-local` server using `address: "localhost"`
- Added a direct routing rule for `inboundTag: ["dns-direct-local"]`
- Updated `app/webpanel/tun_manager_test.go` to cover the new DNS layout and direct routing behavior
- Did not change proxied-domain remote DNS handling, China split-DNS behavior for `geosite:cn`, or add any new UI surface area

## Verification

- [x] `bash scripts/check.sh`
- [x] I tested the affected user flow locally

Local verification notes:
- `go test ./app/webpanel/...`
- rebuilt with `make build`
- reinstalled the local `xray-webpanel` service binary and re-ran `POST /api/v1/tun/install-privilege` until `binaryCurrent=true`
- restarted the user service and enabled transparent TUN locally
- confirmed `/home/leo-cy/Xray-core-laochendeai/runtime/tun/config.json` contains `dns-direct-local` with `address: "localhost"`
- confirmed protected domains include `hifly.cc`, `shortvideo-cdn.lingverse.co`, and `domain:lingverse.co` under `dns-direct-local`
- confirmed `dns-cn` remains only for `geosite:cn`
- confirmed `dns-remote` remains unchanged

## Risks

The change is limited to transparent TUN runtime DNS generation for protected direct domains. During local verification, `POST /api/v1/tun/start` briefly reported an error while `/api/v1/tun/status` converged to `running=true`; this behavior appears pre-existing and is not changed by this PR.
