### PR TITLE
feat: persist node exit IP probe state

### DIFF
--- a/app/webpanel/node_exit_ip_probe.go
+++ b/app/webpanel/node_exit_ip_probe.go
@@ -1,0 +1,122 @@
+package webpanel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	stdnet "net"
+	"net/http"
+	"strings"
+	"time"
+
+	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/common/utils"
+	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/transport/internet/tagged"
+)
+
+type NodeExitIPStatus string
+
+const (
+	NodeExitIPStatusUnknown   NodeExitIPStatus = "unknown"
+	NodeExitIPStatusAvailable NodeExitIPStatus = "available"
+	NodeExitIPStatusError     NodeExitIPStatus = "error"
+)
+
+type nodeExitIPProbeResult struct {
+	IP        string
+	Source    string
+	CheckedAt time.Time
+	Error     string
+}
+
+type nodeExitIPProbeFunc func(ctx context.Context, dispatcher routing.Dispatcher, tag string) nodeExitIPProbeResult
+
+const nodeExitIPProbeTimeout = 5 * time.Second
+
+var nodeExitIPProbeEndpoints = []string{
+	"https://api.ipify.org",
+	"https://ipv4.icanhazip.com",
+	"https://ifconfig.me/ip",
+}
+
+func defaultNodeExitIPProber(ctx context.Context, dispatcher routing.Dispatcher, tag string) nodeExitIPProbeResult {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	tr := &http.Transport{
+		DisableKeepAlives: true,
+		DialContext: func(reqCtx context.Context, network, addr string) (xnet.Conn, error) {
+			dest, err := xnet.ParseDestination(network + ":" + addr)
+			if err != nil {
+				return nil, err
+			}
+			return tagged.Dialer(ctx, dispatcher, dest, tag)
+		},
+	}
+
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   nodeExitIPProbeTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	lastError := ""
+	lastSource := ""
+	for _, endpoint := range nodeExitIPProbeEndpoints {
+		lastSource = endpoint
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			lastError = err.Error()
+			continue
+		}
+		req.Header.Set("User-Agent", utils.ChromeUA)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastError = err.Error()
+			continue
+		}
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 256))
+		resp.Body.Close()
+		if readErr != nil {
+			lastError = readErr.Error()
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastError = fmt.Sprintf("%s returned HTTP %d", endpoint, resp.StatusCode)
+			continue
+		}
+
+		candidate := strings.TrimSpace(string(body))
+		ip := stdnet.ParseIP(candidate)
+		if ip == nil {
+			lastError = fmt.Sprintf("%s returned a non-IP body", endpoint)
+			continue
+		}
+		if ip4 := ip.To4(); ip4 != nil {
+			candidate = ip4.String()
+		} else {
+			candidate = ip.String()
+		}
+
+		return nodeExitIPProbeResult{
+			IP:        candidate,
+			Source:    endpoint,
+			CheckedAt: time.Now().UTC(),
+		}
+	}
+
+	if lastError == "" {
+		lastError = "all exit-IP probe endpoints failed"
+	}
+	return nodeExitIPProbeResult{
+		Source:    lastSource,
+		CheckedAt: time.Now().UTC(),
+		Error:     lastError,
+	}
+}

--- a/app/webpanel/subscription_manager.go
+++ b/app/webpanel/subscription_manager.go
@@ -205,6 +205,11 @@ type NodeRecord struct {
 	LastCheckedAt       *time.Time        `json:"lastCheckedAt,omitempty"`
 	Cleanliness         CleanlinessStatus `json:"cleanliness"`
 	BandwidthTier       BandwidthTier     `json:"bandwidthTier"`
+	ExitIPStatus        NodeExitIPStatus  `json:"exitIpStatus"`
+	ExitIP              string            `json:"exitIp,omitempty"`
+	ExitIPSource        string            `json:"exitIpSource,omitempty"`
+	ExitIPError         string            `json:"exitIpError,omitempty"`
+	ExitIPCheckedAt     *time.Time        `json:"exitIpCheckedAt,omitempty"`
 }
 
 // ValidationConfig holds the criteria for promoting/quarantining nodes.
@@ -237,6 +242,11 @@ type SubscriptionManager struct {
 	bgWG                sync.WaitGroup
 	started             bool
 	dispatcherAvailable bool
+	dispatcher          routing.Dispatcher
+	nodeExitIPProber    nodeExitIPProbeFunc
+	nodeExitIPProbeTTL  time.Duration
+	nodeExitIPErrorTTL  time.Duration
+	nodeExitIPInFlight  map[string]struct{}
 }
 
 const (
@@ -246,6 +256,8 @@ const (
 	legacyDemotedStatus    = "demoted"
 	legacyStagingTagPrefix = "staging_"
 	legacyActiveTagPrefix  = "active_"
+	nodeExitIPProbeTTL     = 6 * time.Hour
+	nodeExitIPErrorTTL     = 15 * time.Minute
 )
 
 // NewSubscriptionManager creates a new SubscriptionManager.
@@ -253,13 +265,17 @@ func NewSubscriptionManager(configPath string, grpcClient *GRPCClient, instance 
 	statePath := filepath.Join(filepath.Dir(configPath), "node_pool_state.json")
 
 	sm := &SubscriptionManager{
-		statePath:  statePath,
-		grpcClient: grpcClient,
-		instance:   instance,
-		runtimeCtx: runtimeCtx,
-		stopCh:     make(chan struct{}),
-		saveCh:     make(chan struct{}, 1),
-		saveDelay:  scheduledPersistDelay,
+		statePath:          statePath,
+		grpcClient:         grpcClient,
+		instance:           instance,
+		runtimeCtx:         runtimeCtx,
+		stopCh:             make(chan struct{}),
+		saveCh:             make(chan struct{}, 1),
+		saveDelay:          scheduledPersistDelay,
+		nodeExitIPProber:   defaultNodeExitIPProber,
+		nodeExitIPProbeTTL: nodeExitIPProbeTTL,
+		nodeExitIPErrorTTL: nodeExitIPErrorTTL,
+		nodeExitIPInFlight: make(map[string]struct{}),
 	}
 
 	state, changed := sm.loadState()
@@ -298,6 +314,7 @@ func (sm *SubscriptionManager) Start() error {
 	}
 	sm.started = true
 	sm.dispatcherAvailable = dispatcher != nil
+	sm.dispatcher = dispatcher
 	sm.mu.Unlock()
 
 	if normalized {
@@ -319,6 +336,13 @@ func (sm *SubscriptionManager) Start() error {
 		}
 		sm.prober.Start()
 	}
+
+	sm.mu.Lock()
+	now := time.Now()
+	for idx := range sm.state.Nodes {
+		sm.maybeScheduleNodeExitIPProbeLocked(idx, now)
+	}
+	sm.mu.Unlock()
 
 	sm.bgWG.Add(1)
 	go func() {
@@ -345,6 +369,7 @@ func (sm *SubscriptionManager) Stop() {
 	sm.mu.Lock()
 	sm.started = false
 	sm.dispatcherAvailable = false
+	sm.dispatcher = nil
 	sm.mu.Unlock()
 	if sm.prober != nil {
 		sm.prober.Stop()
@@ -1205,6 +1230,10 @@ func (sm *SubscriptionManager) handleProbeResults(results []ProbeResult) {
 				sm.applyTransitionLocked(idx, NodeStatusActive, TransitionReasonProbeRequalified, EventActorSystem, "quarantined node re-qualified")
 			}
 		}
+
+		if result.Success {
+			sm.maybeScheduleNodeExitIPProbeLocked(idx, now)
+		}
 	}
 
 	if changed {
@@ -1350,7 +1379,130 @@ func (sm *SubscriptionManager) ensureProbeableLocked(node *NodeRecord) error {
 	if sm.prober != nil {
 		sm.prober.AddTag(node.OutboundTag)
 	}
+	if idx := sm.findNodeByTag(node.OutboundTag); idx >= 0 {
+		sm.maybeScheduleNodeExitIPProbeLocked(idx, time.Now())
+	}
 	return nil
+}
+
+func (sm *SubscriptionManager) maybeScheduleNodeExitIPProbeLocked(idx int, now time.Time) {
+	if idx < 0 || idx >= len(sm.state.Nodes) || sm.dispatcher == nil || sm.nodeExitIPProber == nil {
+		return
+	}
+
+	node := sm.state.Nodes[idx]
+	if !isProbeableStatus(node.Status) || node.OutboundTag == "" {
+		return
+	}
+	if _, ok := sm.nodeExitIPInFlight[node.OutboundTag]; ok {
+		return
+	}
+
+	switch node.ExitIPStatus {
+	case NodeExitIPStatusAvailable:
+		if node.ExitIPCheckedAt != nil && now.Sub(*node.ExitIPCheckedAt) < sm.nodeExitIPProbeTTL {
+			return
+		}
+	case NodeExitIPStatusError:
+		if node.ExitIPCheckedAt != nil && now.Sub(*node.ExitIPCheckedAt) < sm.nodeExitIPErrorTTL {
+			return
+		}
+	}
+
+	sm.nodeExitIPInFlight[node.OutboundTag] = struct{}{}
+	tag := node.OutboundTag
+	sm.bgWG.Add(1)
+	go func() {
+		defer sm.bgWG.Done()
+		sm.runNodeExitIPProbe(tag)
+	}()
+}
+
+func (sm *SubscriptionManager) runNodeExitIPProbe(tag string) {
+	if strings.TrimSpace(tag) == "" {
+		return
+	}
+
+	probeCtx := context.Background()
+	if sm.runtimeCtx != nil && core.FromContext(sm.runtimeCtx) != nil {
+		probeCtx = core.ToBackgroundDetachedContext(sm.runtimeCtx)
+	}
+
+	sm.mu.RLock()
+	dispatcher := sm.dispatcher
+	prober := sm.nodeExitIPProber
+	sm.mu.RUnlock()
+
+	result := nodeExitIPProbeResult{
+		CheckedAt: time.Now().UTC(),
+		Error:     "node exit-IP prober is unavailable",
+	}
+	if dispatcher != nil && prober != nil {
+		result = prober(probeCtx, dispatcher, tag)
+		if result.CheckedAt.IsZero() {
+			result.CheckedAt = time.Now().UTC()
+		}
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	delete(sm.nodeExitIPInFlight, tag)
+
+	idx := sm.findNodeByTag(tag)
+	if idx < 0 {
+		return
+	}
+	if applyNodeExitIPProbeResult(&sm.state.Nodes[idx], result) {
+		sm.requestScheduledSave()
+	}
+}
+
+func applyNodeExitIPProbeResult(node *NodeRecord, result nodeExitIPProbeResult) bool {
+	if node == nil {
+		return false
+	}
+
+	changed := false
+	checkedAt := result.CheckedAt
+	if checkedAt.IsZero() {
+		checkedAt = time.Now().UTC()
+	}
+	if node.ExitIPCheckedAt == nil || !node.ExitIPCheckedAt.Equal(checkedAt) {
+		node.ExitIPCheckedAt = &checkedAt
+		changed = true
+	}
+
+	if result.IP != "" && node.ExitIP != result.IP {
+		node.ExitIP = result.IP
+		changed = true
+	}
+	if node.ExitIPSource != result.Source {
+		node.ExitIPSource = result.Source
+		changed = true
+	}
+
+	if result.Error == "" {
+		if node.ExitIPStatus != NodeExitIPStatusAvailable {
+			node.ExitIPStatus = NodeExitIPStatusAvailable
+			changed = true
+		}
+		if node.ExitIPError != "" {
+			node.ExitIPError = ""
+			changed = true
+		}
+		return changed
+	}
+
+	if node.ExitIPStatus != NodeExitIPStatusError {
+		node.ExitIPStatus = NodeExitIPStatusError
+		changed = true
+	}
+	if node.ExitIPError != result.Error {
+		node.ExitIPError = result.Error
+		changed = true
+	}
+	return changed
 }
 
 func (sm *SubscriptionManager) removeProbeableLocked(node *NodeRecord) {
@@ -1832,6 +1984,10 @@ func normalizeNodeRecord(node *NodeRecord, now time.Time) bool {
 
 	if node.Cleanliness == "" {
 		node.Cleanliness = CleanlinessUnknown
+		changed = true
+	}
+	if node.ExitIPStatus == "" {
+		node.ExitIPStatus = NodeExitIPStatusUnknown
 		changed = true
 	}
 	if node.BandwidthTier == "" {

--- a/app/webpanel/subscription_manager_test.go
+++ b/app/webpanel/subscription_manager_test.go
@@ -12,12 +12,40 @@ import (
 	"time"
 
 	handlerservice "github.com/xtls/xray-core/app/proxyman/command"
+	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/features/routing"
+	"github.com/xtls/xray-core/transport"
 	"google.golang.org/grpc"
 )
 
 type stubHandlerServiceClient struct {
 	addedTags   []string
 	removedTags []string
+}
+
+type stubRoutingDispatcher struct{}
+
+func (s *stubRoutingDispatcher) Type() interface{} { return routing.DispatcherType() }
+func (s *stubRoutingDispatcher) Start() error      { return nil }
+func (s *stubRoutingDispatcher) Close() error      { return nil }
+func (s *stubRoutingDispatcher) Dispatch(context.Context, xnet.Destination) (*transport.Link, error) {
+	return nil, nil
+}
+func (s *stubRoutingDispatcher) DispatchLink(context.Context, xnet.Destination, *transport.Link) error {
+	return nil
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool, description string) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
 }
 
 func (s *stubHandlerServiceClient) AddInbound(context.Context, *handlerservice.AddInboundRequest, ...grpc.CallOption) (*handlerservice.AddInboundResponse, error) {
@@ -211,6 +239,176 @@ func TestSubscriptionManagerHandleProbeResultsUpdatesLifecycle(t *testing.T) {
 	if summary.QuarantineCount != 1 {
 		t.Fatalf("expected 1 quarantined node in summary, got %d", summary.QuarantineCount)
 	}
+}
+
+func TestSubscriptionManagerHandleProbeResultsStoresNodeExitIP(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	statePath := filepath.Join(tempDir, "node_pool_state.json")
+	sm := NewSubscriptionManager(configPath, nil, nil, nil)
+	sm.saveDelay = 5 * time.Millisecond
+	sm.dispatcher = &stubRoutingDispatcher{}
+	sm.nodeExitIPProber = func(context.Context, routing.Dispatcher, string) nodeExitIPProbeResult {
+		return nodeExitIPProbeResult{
+			IP:        "203.0.113.44",
+			Source:    "https://api.ipify.org",
+			CheckedAt: time.Now().UTC(),
+		}
+	}
+	defer sm.Stop()
+
+	sm.mu.Lock()
+	sm.state.Nodes = []NodeRecord{
+		{
+			ID:               "node-exit-ip-success",
+			URI:              "vmess://example",
+			Remark:           "probeable",
+			Status:           NodeStatusActive,
+			StatusReason:     TransitionReasonManualPromote,
+			SubscriptionID:   "sub-1",
+			AddedAt:          time.Now().Add(-time.Minute),
+			OutboundTag:      probeOutboundTag("node-exit-ip-success"),
+			Cleanliness:      CleanlinessUnknown,
+			BandwidthTier:    BandwidthTierUnknown,
+			ExitIPStatus:     NodeExitIPStatusUnknown,
+			TotalPings:       4,
+			FailedPings:      0,
+			AvgDelayMs:       120,
+			ConsecutiveFails: 0,
+		},
+	}
+	sm.mu.Unlock()
+
+	sm.handleProbeResults([]ProbeResult{{
+		Tag:     probeOutboundTag("node-exit-ip-success"),
+		Success: true,
+		DelayMs: 88,
+	}})
+
+	waitFor(t, time.Second, func() bool {
+		nodes := sm.ListNodes("")
+		return len(nodes) == 1 && nodes[0].ExitIPStatus == NodeExitIPStatusAvailable && nodes[0].ExitIP == "203.0.113.44"
+	}, "node exit IP probe success")
+
+	sm.mu.Lock()
+	sm.writeStateLocked()
+	sm.mu.Unlock()
+
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	var persisted NodePoolState
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("decode persisted state: %v", err)
+	}
+	if len(persisted.Nodes) != 1 || persisted.Nodes[0].ExitIP != "203.0.113.44" || persisted.Nodes[0].ExitIPStatus != NodeExitIPStatusAvailable {
+		t.Fatalf("unexpected persisted exit IP state: %#v", persisted.Nodes)
+	}
+}
+
+func TestSubscriptionManagerHandleProbeResultsCachesFreshNodeExitIP(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	sm := NewSubscriptionManager(configPath, nil, nil, nil)
+	sm.saveDelay = 5 * time.Millisecond
+	sm.dispatcher = &stubRoutingDispatcher{}
+	sm.nodeExitIPProbeTTL = time.Hour
+
+	callCount := 0
+	sm.nodeExitIPProber = func(context.Context, routing.Dispatcher, string) nodeExitIPProbeResult {
+		callCount++
+		return nodeExitIPProbeResult{
+			IP:        "203.0.113.45",
+			Source:    "https://api.ipify.org",
+			CheckedAt: time.Now().UTC(),
+		}
+	}
+	defer sm.Stop()
+
+	checkedAt := time.Now().Add(-5 * time.Minute).UTC()
+	sm.mu.Lock()
+	sm.state.Nodes = []NodeRecord{
+		{
+			ID:              "node-exit-ip-cache",
+			URI:             "vmess://example",
+			Remark:          "fresh-cache",
+			Status:          NodeStatusActive,
+			StatusReason:    TransitionReasonManualPromote,
+			SubscriptionID:  "sub-1",
+			AddedAt:         time.Now().Add(-time.Minute),
+			OutboundTag:     probeOutboundTag("node-exit-ip-cache"),
+			Cleanliness:     CleanlinessUnknown,
+			BandwidthTier:   BandwidthTierUnknown,
+			ExitIPStatus:    NodeExitIPStatusAvailable,
+			ExitIP:          "203.0.113.45",
+			ExitIPSource:    "https://api.ipify.org",
+			ExitIPCheckedAt: &checkedAt,
+		},
+	}
+	sm.mu.Unlock()
+
+	sm.handleProbeResults([]ProbeResult{{
+		Tag:     probeOutboundTag("node-exit-ip-cache"),
+		Success: true,
+		DelayMs: 52,
+	}})
+
+	time.Sleep(100 * time.Millisecond)
+	if callCount != 0 {
+		t.Fatalf("expected no exit-IP reprobe for fresh cache, got %d calls", callCount)
+	}
+}
+
+func TestSubscriptionManagerHandleProbeResultsStoresNodeExitIPError(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	sm := NewSubscriptionManager(configPath, nil, nil, nil)
+	sm.saveDelay = 5 * time.Millisecond
+	sm.dispatcher = &stubRoutingDispatcher{}
+	sm.nodeExitIPProber = func(context.Context, routing.Dispatcher, string) nodeExitIPProbeResult {
+		return nodeExitIPProbeResult{
+			Source:    "https://api.ipify.org",
+			CheckedAt: time.Now().UTC(),
+			Error:     "probe timeout",
+		}
+	}
+	defer sm.Stop()
+
+	sm.mu.Lock()
+	sm.state.Nodes = []NodeRecord{
+		{
+			ID:             "node-exit-ip-error",
+			URI:            "vmess://example",
+			Remark:         "probe-error",
+			Status:         NodeStatusStaging,
+			StatusReason:   TransitionReasonSubscriptionNodeDiscovered,
+			SubscriptionID: "sub-1",
+			AddedAt:        time.Now().Add(-time.Minute),
+			OutboundTag:    probeOutboundTag("node-exit-ip-error"),
+			Cleanliness:    CleanlinessUnknown,
+			BandwidthTier:  BandwidthTierUnknown,
+			ExitIPStatus:   NodeExitIPStatusUnknown,
+		},
+	}
+	sm.mu.Unlock()
+
+	sm.handleProbeResults([]ProbeResult{{
+		Tag:     probeOutboundTag("node-exit-ip-error"),
+		Success: true,
+		DelayMs: 44,
+	}})
+
+	waitFor(t, time.Second, func() bool {
+		nodes := sm.ListNodes("")
+		return len(nodes) == 1 && nodes[0].ExitIPStatus == NodeExitIPStatusError && nodes[0].ExitIPError == "probe timeout"
+	}, "node exit IP probe error")
 }
 
 func TestSubscriptionManagerDoesNotRequalifyQuarantineNodeOnFailedProbe(t *testing.T) {


### PR DESCRIPTION
Closes #58

## Summary

Persist node-level exit-IP probe state in the WebPanel so probeable nodes can cache a last-known public egress IP, surface machine-readable probe status/errors, and reuse that state for later intelligence features.

## Linked Issue

Closes #58.

## Scope

- What changed
- Added a node exit-IP probe path that runs through existing outbound tags and persists exit-IP fields on node records.
- Scheduled exit-IP probing off the existing node lifecycle / health-probe flow with cache and error backoff windows.
- Added focused WebPanel tests covering success persistence, cache reuse, and error-state recording.
- What did not change
- No cleanliness or residential/datacenter classification yet.
- No Node Pool UI changes yet.
- No destination-to-node binding workflow yet.

## Verification

- [x] `bash scripts/check.sh`
- [x] I tested the affected user flow locally

Relevant local verification:
- `go test ./app/webpanel -run 'TestSubscriptionManagerHandleProbeResults(UpdatesLifecycle|StoresNodeExitIP|CachesFreshNodeExitIP|StoresNodeExitIPError)' -count=1 -v`
- `go test ./app/webpanel -count=1`
- `bash scripts/check.sh`

## Risks

Main risk is probe-volume or timing behavior if large node pools trigger too many exit-IP probes at once, though this change keeps a success TTL and an error backoff to avoid per-refresh probing.
