### PR TITLE
Support VLESS encryption import in WebPanel

### DIFF
--- a/app/webpanel/outbound_config_test.go
+++ b/app/webpanel/outbound_config_test.go
@@ -12,6 +12,8 @@ import (
 	anytls "github.com/xtls/xray-core/proxy/anytls"
 	hysteriaproxy "github.com/xtls/xray-core/proxy/hysteria"
 	shadowsocks2022 "github.com/xtls/xray-core/proxy/shadowsocks_2022"
+	vless "github.com/xtls/xray-core/proxy/vless"
+	vlessoutbound "github.com/xtls/xray-core/proxy/vless/outbound"
 	internettransport "github.com/xtls/xray-core/transport/internet"
 	salamandermask "github.com/xtls/xray-core/transport/internet/finalmask/salamander"
 	hysteriatransport "github.com/xtls/xray-core/transport/internet/hysteria"
@@ -154,6 +156,36 @@ func TestBuildOutboundHandlerConfigFromLinkBuildsRealityStream(t *testing.T) {
 	}
 	if realityConfig.ServerName != "" {
 		t.Fatalf("expected empty reality server name when link omits sni/host, got %q", realityConfig.ServerName)
+	}
+}
+
+func TestBuildOutboundHandlerConfigFromLinkPreservesVLESSEncryption(t *testing.T) {
+	t.Parallel()
+
+	link, err := ParseShareLinkURI(`vless://11111111-1111-1111-1111-111111111111@example.com:443?type=tcp&security=tls&encryption=mlkem768x25519plus#pq-vless`)
+	if err != nil {
+		t.Fatalf("parse vless encryption share link: %v", err)
+	}
+
+	config, err := buildOutboundHandlerConfigFromLink(link, "pool-vless-encryption-test")
+	if err != nil {
+		t.Fatalf("build outbound handler config from vless encryption link: %v", err)
+	}
+
+	proxyConfig, err := typedMessageAs[*vlessoutbound.Config](config.ProxySettings)
+	if err != nil {
+		t.Fatalf("decode vless proxy settings: %v", err)
+	}
+	if proxyConfig.GetVnext() == nil || proxyConfig.GetVnext().GetUser() == nil {
+		t.Fatal("expected vless server endpoint and user to be populated")
+	}
+
+	account, err := typedMessageAs[*vless.Account](proxyConfig.GetVnext().GetUser().GetAccount())
+	if err != nil {
+		t.Fatalf("decode vless account: %v", err)
+	}
+	if got := account.GetEncryption(); got != "mlkem768x25519plus" {
+		t.Fatalf("expected vless encryption mlkem768x25519plus, got %q", got)
 	}
 }
 

--- a/app/webpanel/share_link_parser.go
+++ b/app/webpanel/share_link_parser.go
@@ -531,7 +531,7 @@ func buildVLESSSettings(req *ShareLinkRequest) map[string]interface{} {
 		"users": []map[string]interface{}{
 			{
 				"id":         req.UUID,
-				"encryption": "none",
+				"encryption": normalizedVLESSEncryption(req.Security),
 				"flow":       req.Flow,
 			},
 		},

--- a/app/webpanel/share_link_parser_test.go
+++ b/app/webpanel/share_link_parser_test.go
@@ -81,6 +81,22 @@ func TestParseSubscriptionContentIncludesAnyTLS(t *testing.T) {
 	}
 }
 
+func TestParseShareLinkURIParsesVLESSEncryption(t *testing.T) {
+	t.Parallel()
+
+	req, err := ParseShareLinkURI(`vless://11111111-1111-1111-1111-111111111111@example.com:443?type=tcp&security=tls&encryption=mlkem768x25519plus#pq-vless`)
+	if err != nil {
+		t.Fatalf("ParseShareLinkURI returned error: %v", err)
+	}
+
+	if req.Protocol != "vless" {
+		t.Fatalf("expected vless protocol, got %q", req.Protocol)
+	}
+	if req.Security != "mlkem768x25519plus" {
+		t.Fatalf("expected vless encryption to be preserved, got %q", req.Security)
+	}
+}
+
 func TestParseShareLinkURIParsesSSV2RayPlugin(t *testing.T) {
 	t.Parallel()
 
@@ -258,6 +274,49 @@ func TestBuildOutboundJSONUsesTopLevelHysteriaAddress(t *testing.T) {
 	}
 	if _, ok := settings["server"]; ok {
 		t.Fatal("did not expect nested hysteria server object")
+	}
+}
+
+func TestBuildOutboundJSONPreservesVLESSEncryption(t *testing.T) {
+	t.Parallel()
+
+	req, err := ParseShareLinkURI(`vless://11111111-1111-1111-1111-111111111111@example.com:443?type=tcp&security=tls&encryption=mlkem768x25519plus#pq-vless`)
+	if err != nil {
+		t.Fatalf("ParseShareLinkURI returned error: %v", err)
+	}
+
+	outboundJSON, err := BuildOutboundJSON(req, "pool-vless-encryption")
+	if err != nil {
+		t.Fatalf("BuildOutboundJSON returned error: %v", err)
+	}
+
+	var outbound map[string]any
+	if err := json.Unmarshal(outboundJSON, &outbound); err != nil {
+		t.Fatalf("unmarshal outbound JSON: %v", err)
+	}
+
+	settings, ok := outbound["settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected settings object, got %T", outbound["settings"])
+	}
+	vnext, ok := settings["vnext"].([]any)
+	if !ok || len(vnext) != 1 {
+		t.Fatalf("expected one vnext entry, got %#v", settings["vnext"])
+	}
+	server, ok := vnext[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected vnext server object, got %T", vnext[0])
+	}
+	users, ok := server["users"].([]any)
+	if !ok || len(users) != 1 {
+		t.Fatalf("expected one vless user, got %#v", server["users"])
+	}
+	user, ok := users[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected vless user object, got %T", users[0])
+	}
+	if got := user["encryption"]; got != "mlkem768x25519plus" {
+		t.Fatalf("expected vless encryption mlkem768x25519plus, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve the VLESS `encryption` parameter when imported share links are converted into outbound settings
- add parser and outbound-build tests so VLESS Encryption / ML-KEM links no longer collapse back to `none`
- keep adjacent VLESS/REALITY/AnyTLS paths covered by targeted regression checks

## Testing
- `go test ./app/webpanel -run 'TestParseShareLinkURIParsesVLESSEncryption|TestBuildOutboundJSONPreservesVLESSEncryption|TestBuildOutboundHandlerConfigFromLinkPreservesVLESSEncryption|TestBuildOutboundHandlerConfigFromLinkBuildsRealityStream|TestBuildOutboundJSONSupportsAnyTLS' -count=1`
- `go test ./app/webpanel/...`
- `bash scripts/check.sh`
- `python3 tests/test_web_smoke.py`

Closes #21
