### PR TITLE
Prepare WebPanel v1.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Release packaging workflows in [`.github/workflows/release.yml`](.github/workflo
 
 ### Release Matrix
 
-The matrix below describes what the current release workflows produce. It reflects the workflow definitions in [`.github/workflows/release.yml`](.github/workflows/release.yml), [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml), and [`.github/workflows/docker.yml`](.github/workflows/docker.yml). Existing zip examples are based on release `webpanel-v1.2.2`; the Windows installer entry reflects the workflow added on this branch.
+The matrix below describes what the current release workflows produce. It reflects the workflow definitions in [`.github/workflows/release.yml`](.github/workflows/release.yml), [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml), and [`.github/workflows/docker.yml`](.github/workflows/docker.yml). Existing zip examples are based on release `webpanel-v1.3.0`; the Windows installer entry reflects the workflow added on this branch.
 
 #### Binary Packages
 

--- a/packaging/releases/webpanel-v1.3.0.md
+++ b/packaging/releases/webpanel-v1.3.0.md
@@ -1,0 +1,8 @@
+Webpanel v1.3.0
+
+- Added Node Pool intelligence so active nodes expose exit IP, cleanliness, and network-type hints directly in the WebPanel.
+- Added transparent destination bindings so OpenAI, ChatGPT, and custom domains can be pinned to a chosen active node.
+- Added first-slice AnyTLS support plus share-link canonicalization, and preserved VLESS encryption values during link import.
+- Expanded transparent-mode diagnostics with direct/proxy egress reporting, DNS path visibility, baseline verification, and the readiness center.
+- Added experimental UDP/QUIC aggregation scaffolding with local prototype and relay benchmark diagnostics so aggregation work can be inspected without replacing the stable single-path runtime.
+- Based on Xray core 26.2.6; this WebPanel feature release does not change the upstream core version number.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xray-webpanel",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xray-webpanel",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "dependencies": {
         "axios": "^1.7.0",
         "echarts": "^5.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-webpanel",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the packaged WebPanel metadata from `1.2.2` to `1.3.0`
- refresh the release matrix example tag in `README.md`
- add a versioned release-notes source file for `webpanel-v1.3.0`

## Audit
- Node Pool now surfaces exit IP, cleanliness, and network-type intelligence
- transparent mode now supports destination bindings for OpenAI, ChatGPT, and custom domains
- AnyTLS support and share-link handling were added, and VLESS encryption import is preserved
- transparent diagnostics expanded with readiness, DNS path visibility, and aggregation diagnostics
- upstream core version remains `26.2.6`

## Verification
- `bash scripts/check.sh`
- `git diff --check`

Closes #70