### PR TITLE
Fix #76 align TUN route preview with the actual runtime config

### DIFF
--- a/app/webpanel/handler_routing.go
+++ b/app/webpanel/handler_routing.go
@@ -215,20 +215,8 @@ func (wp *WebPanel) previewTunRoute(testReq routingTestRequest) (tunRoutePreview
 	if wp.tunManager == nil {
 		return tunRoutePreviewResult{}, fmt.Errorf("TUN manager is not configured")
 	}
-	if wp.subManager == nil {
-		return tunRoutePreviewResult{}, fmt.Errorf("subscription manager is not configured")
-	}
 
-	settings, err := wp.tunManager.SettingsSnapshot()
-	if err != nil {
-		return tunRoutePreviewResult{}, err
-	}
-	raw, err := os.ReadFile(wp.tunManager.configPath)
-	if err != nil {
-		return tunRoutePreviewResult{}, err
-	}
-	activeNodes := wp.subManager.ListNodesByStatuses(NodeStatusActive)
-	runtimeConfig, err := buildTunRuntimeConfig(raw, settings, activeNodes)
+	runtimeConfig, err := wp.previewTunRuntimeConfig()
 	if err != nil {
 		return tunRoutePreviewResult{}, err
 	}
@@ -244,6 +232,41 @@ func (wp *WebPanel) previewTunRoute(testReq routingTestRequest) (tunRoutePreview
 		User:       testReq.User,
 		InboundTag: testReq.InboundTag,
 	})
+}
+
+func (wp *WebPanel) previewTunRuntimeConfig() ([]byte, error) {
+	if wp.tunManager == nil {
+		return nil, fmt.Errorf("TUN manager is not configured")
+	}
+
+	settings, err := wp.tunManager.SettingsSnapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	status := wp.tunManager.Status()
+	if status != nil && status.Running {
+		runtimeConfig, readErr := os.ReadFile(settings.RuntimeConfigPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read running TUN runtime config: %w", readErr)
+		}
+		return runtimeConfig, nil
+	}
+
+	if wp.subManager == nil {
+		return nil, fmt.Errorf("subscription manager is not configured")
+	}
+
+	raw, err := os.ReadFile(wp.tunManager.configPath)
+	if err != nil {
+		return nil, err
+	}
+	eligibleNodes, _ := wp.eligibleTransparentNodes()
+	runtimeConfig, err := buildTunRuntimeConfig(raw, settings, eligibleNodes)
+	if err != nil {
+		return nil, err
+	}
+	return runtimeConfig, nil
 }
 
 // handleBalancers handles GET/PUT /api/v1/routing/balancers/:tag.

--- a/app/webpanel/handler_routing_test.go
+++ b/app/webpanel/handler_routing_test.go
@@ -1,0 +1,169 @@
+package webpanel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writePreviewTunTestConfig(t *testing.T, helperPath string, runtimeConfigPath string, destinationBindings string) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	config := `{
+  "outbounds": [
+    { "tag": "direct", "protocol": "freedom" }
+  ],
+  "routing": {
+    "rules": []
+  },
+  "webpanel": {
+    "tun": {
+      "helperPath": "` + helperPath + `",
+      "runtimeConfigPath": "` + runtimeConfigPath + `",
+      "interfaceName": "xray0",
+      "mtu": 1500,
+      "useSudo": false,
+      "protectDomains": ["full:localhost"],
+      "protectCidrs": ["127.0.0.0/8"],
+      "destinationBindings": ` + destinationBindings + `
+    }
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return configPath
+}
+
+func writePreviewTunHelper(t *testing.T, action string) string {
+	t.Helper()
+
+	helperPath := filepath.Join(t.TempDir(), "webpanel-tun-helper.sh")
+	content := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  status)\n" +
+		"    echo \"ACTION=status:" + action + "\"\n" +
+		"    ;;\n" +
+		"  *)\n" +
+		"    echo \"ACTION=$1:" + action + "\"\n" +
+		"    ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(helperPath, []byte(content), 0o755); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	return helperPath
+}
+
+func TestWebPanelPreviewTunRouteUsesRunningRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	helperPath := writePreviewTunHelper(t, "running")
+	runtimeConfigPath := filepath.Join(t.TempDir(), "runtime.json")
+	runtimeConfig := `{
+  "routing": {
+    "rules": [
+      {
+        "type": "field",
+        "domain": ["domain:api.openai.com"],
+        "outboundTag": "pool-active-runtime-node"
+      },
+      {
+        "type": "field",
+        "inboundTag": ["tun-in"],
+        "balancerTag": "node-pool-active"
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(runtimeConfigPath, []byte(runtimeConfig), 0o644); err != nil {
+		t.Fatalf("write runtime config: %v", err)
+	}
+
+	configPath := writePreviewTunTestConfig(t, helperPath, runtimeConfigPath, `[
+        {"preset":"openai","nodeId":"different-node"}
+      ]`)
+	tunManager, err := NewTunManager(configPath)
+	if err != nil {
+		t.Fatalf("new tun manager: %v", err)
+	}
+
+	wp := &WebPanel{tunManager: tunManager}
+	result, err := wp.previewTunRoute(routingTestRequest{
+		Scope:      "tun",
+		Domain:     "api.openai.com",
+		Port:       443,
+		Network:    "tcp",
+		InboundTag: "tun-in",
+	})
+	if err != nil {
+		t.Fatalf("preview tun route: %v", err)
+	}
+
+	if result.OutboundTag != "pool-active-runtime-node" {
+		t.Fatalf("expected running runtime config to win, got %+v", result)
+	}
+}
+
+func TestWebPanelPreviewTunRouteUsesEligibleNodesWhenStopped(t *testing.T) {
+	t.Parallel()
+
+	helperPath := writePreviewTunHelper(t, "stopped")
+	runtimeConfigPath := filepath.Join(t.TempDir(), "runtime.json")
+	configPath := writePreviewTunTestConfig(t, helperPath, runtimeConfigPath, `[
+        {"preset":"openai","nodeId":"target-node"}
+      ]`)
+	tunManager, err := NewTunManager(configPath)
+	if err != nil {
+		t.Fatalf("new tun manager: %v", err)
+	}
+
+	now := time.Now()
+	wp := &WebPanel{
+		tunManager: tunManager,
+		subManager: &SubscriptionManager{
+			state: &NodePoolState{
+				ValidationConfig: defaultValidationConfig(),
+				Nodes: []NodeRecord{
+					{
+						ID:               "target-node",
+						Status:           NodeStatusActive,
+						URI:              mustGenerateTunTestURI(t, "203.0.113.10"),
+						Protocol:         "vmess",
+						AvgDelayMs:       120,
+						ConsecutiveFails: 1,
+						LastCheckedAt:    &now,
+					},
+					{
+						ID:               "fallback-node",
+						Status:           NodeStatusActive,
+						URI:              mustGenerateTunTestURI(t, "203.0.113.11"),
+						Protocol:         "vmess",
+						AvgDelayMs:       80,
+						ConsecutiveFails: 0,
+						LastCheckedAt:    &now,
+					},
+				},
+			},
+		},
+	}
+
+	result, err := wp.previewTunRoute(routingTestRequest{
+		Scope:      "tun",
+		Domain:     "api.openai.com",
+		Port:       443,
+		Network:    "tcp",
+		InboundTag: "tun-in",
+	})
+	if err != nil {
+		t.Fatalf("preview tun route: %v", err)
+	}
+
+	if result.OutboundTag != "" {
+		t.Fatalf("expected ineligible binding target to be skipped, got %+v", result)
+	}
+	if result.BalancerTag != "node-pool-active" {
+		t.Fatalf("expected catch-all balancer when target node is not TUN-eligible, got %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the `scope=tun` route-preview path so destination-binding verification matches the actual transparent TUN runtime instead of a drift-prone reconstructed config.

## What Changed

- read the real `runtime/tun/config.json` when transparent mode is already running
- make offline TUN preview use the same transparent-eligible node subset as real startup
- add regression tests for both the running-runtime path and the eligible-node preview path

## Why

The previous implementation could show a false-positive binding match in the WebPanel even when the real running TUN runtime was not using that bound node.

## Verification

- `go test ./app/webpanel -run 'TestWebPanelPreviewTunRouteUsesRunningRuntimeConfig|TestWebPanelPreviewTunRouteUsesEligibleNodesWhenStopped|TestPreviewTunRouteMatchesDestinationBinding'`
- `go test ./app/webpanel`
- repository pre-push checks passed:
  - Go webpanel tests
  - web vitest suite
  - web build
  - web smoke tests
- real-machine verification on this host after restart:
  - rebuilt and restarted `/home/leo-cy/Xray-core-laochendeai-latest/xray`
  - reinstalled the privilege helper so the TUN binary matched the new WebPanel binary
  - re-enabled transparent mode successfully
  - confirmed `/home/leo-cy/Xray-core-laochendeai/runtime/tun/config.json` now contains the OpenAI binding rule with `outboundTag: pool-active-a025cebcf677`
  - confirmed `POST /api/v1/routing/test` with `scope=tun` for `api.openai.com:443` returns `pool-active-a025cebcf677`

## Issue

Closes #76
