### PR TITLE
Release v2026.4.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Release packaging workflows in [`.github/workflows/release.yml`](.github/workflo
 
 ### Release Matrix
 
-The matrix below describes what the current release workflows produce. It reflects the workflow definitions in [`.github/workflows/release.yml`](.github/workflows/release.yml), [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml), and [`.github/workflows/docker.yml`](.github/workflows/docker.yml). Existing zip examples are based on release `v2026.4.10`; the Windows installer entry reflects the workflow added on this branch.
+The matrix below describes what the current release workflows produce. It reflects the workflow definitions in [`.github/workflows/release.yml`](.github/workflows/release.yml), [`.github/workflows/release-win7.yml`](.github/workflows/release-win7.yml), and [`.github/workflows/docker.yml`](.github/workflows/docker.yml). Existing zip examples are based on release `v2026.4.11`; the Windows installer entry reflects the workflow added on this branch.
 
 #### Binary Packages
 

--- a/docs/releases/v2026.4.11.md
+++ b/docs/releases/v2026.4.11.md
@@ -1,0 +1,19 @@
+# v2026.4.11
+
+Release date: 2026-04-11
+
+## Highlights
+
+- Fixed transparent TUN destination-binding verification so the WebPanel route-preview result now matches the actual running `runtime/tun/config.json`.
+- When transparent mode is already running, `scope=tun` route tests now read the live runtime config instead of rebuilding a separate in-memory preview.
+- When transparent mode is stopped, the preview path now uses the same transparent-eligible node subset as real startup, preventing false-positive binding matches.
+
+## Verification
+
+- `bash scripts/check.sh`
+- Real-machine restart and transparent-mode verification on the local WebPanel at `http://127.0.0.1:19527`
+- Confirmed `POST /api/v1/routing/test` with `scope=tun` for `api.openai.com:443` returns the same outbound tag written into `runtime/tun/config.json`
+
+## Known Notes
+
+- The dashboard's release checker still reads the upstream `XTLS/Xray-core` release feed. This date-based release tag is for this fork's release workflow and distribution artifacts.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xray-webpanel",
-  "version": "2026.4.10",
+  "version": "2026.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xray-webpanel",
-      "version": "2026.4.10",
+      "version": "2026.4.11",
       "dependencies": {
         "axios": "^1.7.0",
         "echarts": "^5.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-webpanel",
-  "version": "2026.4.10",
+  "version": "2026.4.11",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Publish the current fork release as `v2026.4.11`.

## What Changed

- bumped the embedded WebPanel package version from `2026.4.10` to `2026.4.11`
- added `docs/releases/v2026.4.11.md`
- updated the README release-matrix reference from `v2026.4.10` to `v2026.4.11`
- carried forward the destination-binding preview/runtime-alignment fix from #76 / #77 into the dated release notes

## Verification

- `bash scripts/check.sh`
- local real-machine verification already completed for #76 / #77:
  - transparent TUN restarted successfully
  - `runtime/tun/config.json` contains the OpenAI binding rule
  - `POST /api/v1/routing/test` with `scope=tun` returns the bound outbound tag

## Release Follow-up

After this PR lands:
- create and push tag `v2026.4.11`
- publish the GitHub Release for `v2026.4.11`

Closes #78
