### PR TITLE
Add repository governance guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Default owner for repository changes
+* @laochendeai
+
+# Repository governance and workflow surfaces
+/CLAUDE.md @laochendeai
+/CONTRIBUTING.md @laochendeai
+/README.md @laochendeai
+/.github/CODEOWNERS @laochendeai
+/.github/ISSUE_TEMPLATE/ @laochendeai
+/.github/pull_request_template.md @laochendeai
+/.github/workflows/ci.yml @laochendeai
+/.github/workflows/release*.yml @laochendeai
+/.github/workflows/docker.yml @laochendeai
+/.githooks/ @laochendeai
+/scripts/check.sh @laochendeai
+/REAL_MACHINE_VERIFICATION.md @laochendeai
+/SECURITY.md @laochendeai
+/CODE_OF_CONDUCT.md @laochendeai

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,8 @@ Use a closing keyword above, for example `Closes #123`.
 
 - [ ] `bash scripts/check.sh`
 - [ ] I tested the affected user flow locally
+- [ ] UI text changes updated both `web/src/i18n/locales/zh-CN.json` and `web/src/i18n/locales/en.json`, or this PR does not change UI text
+- [ ] Runtime-sensitive changes include verification notes from `REAL_MACHINE_VERIFICATION.md`, or this PR is not runtime-sensitive
 
 Paste any relevant output, screenshots, or notes here.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ backups/
 control_plane_state.json
 node_pool_state.json
 dev-config.current-nodes.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # System files
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+# Xray-core (laochendeai fork) repository rules
+
+This file is the project-specific rule layer for agent work in this repository. Use it together with the existing issue, PR, hook, and verification assets that already live in the repo.
+
+## Repository identity
+
+- This repository is a maintained fork of Xray-core with an embedded WebPanel and a local control plane for subscriptions, node-pool lifecycle management, TUN orchestration, DNS split-policy, and update discovery.
+- Treat changes here as product changes to a local runtime and control plane, not as isolated library edits.
+- Prefer the smallest change that satisfies the requested outcome. Do not widen scope without user approval.
+
+## Required change workflow
+
+- For planned work, start from an issue. Use `.github/ISSUE_TEMPLATE/change-request.md` when opening or refining a change request.
+- Work on one issue per branch. Do not mix unrelated changes in the same branch.
+- Before push or PR, run `bash scripts/check.sh`.
+- Keep `.githooks/pre-push` enabled so the local push gate matches the repository workflow.
+- PR bodies must include a closing issue reference such as `Closes #123`, matching `.github/pull_request_template.md` and `.github/workflows/ci.yml`.
+
+## Planning gate for non-trivial work
+
+Make a brief implementation plan before editing when the task is non-trivial.
+
+Use a plan first when the change:
+- touches TUN, DNS, routing, transparent proxy behavior, startup, clean-state enforcement, or runtime helpers
+- changes node-pool lifecycle, quarantine logic, subscription import, or validation flow
+- changes both Go backend behavior and WebPanel behavior
+- changes release packaging, GitHub Actions, installer behavior, or other distribution logic
+- renames, deletes, or migrates important config, state, or API fields
+
+The plan should capture:
+- the requested outcome
+- the files or flows that will change
+- the main regression surface
+- the verification path, including whether `REAL_MACHINE_VERIFICATION.md` is required
+
+## Verification and regression guard
+
+- `bash scripts/check.sh` is the default local verification gate. Do not invent a second primary check path.
+- Treat regression checking as broader than “the file I edited.” Verify adjacent user flows, API callers, config/state contracts, and docs that could drift because of the change.
+- For frontend or WebPanel changes, verify the affected route and the main user path locally, not only via tests.
+- For backend or API changes, verify the affected caller path in the WebPanel when applicable.
+- If behavior, workflow, or release expectations changed, update the relevant documentation in the same change.
+
+## Runtime and network safety
+
+Runtime-sensitive changes require more than unit tests.
+
+Use `REAL_MACHINE_VERIFICATION.md` when the change affects:
+- TUN enable / disable / restore behavior
+- control-plane fallback, clean-state, or reboot-sensitive logic
+- routing, DNS, direct-vs-proxy policy, or startup state restoration
+- scripts or helpers that interact with local machine networking or service startup
+
+Do not claim runtime verification unless you actually performed it or clearly say why it was not run.
+
+## Hook gate and CI parity
+
+- `scripts/check.sh` is the single local gate and `.githooks/pre-push` is the local hook mirror of that gate.
+- Keep local verification aligned with `.github/workflows/ci.yml` rather than creating a separate undocumented workflow.
+- Do not bypass hooks unless the user explicitly asks for it.
+
+## Worktree isolation
+
+Prefer an isolated worktree when:
+- the task is multi-step or risky
+- the current working tree is already dirty
+- multiple issues are being worked on in parallel
+- the change affects runtime behavior, packaging, or other high-regression surfaces
+
+Do not mix unrelated fixes into the same worktree or branch.
+
+## Repo closeout
+
+Before considering work complete:
+- leave the intended branch/worktree in a reviewable state
+- summarize what was verified
+- call out any remaining risk or follow-up
+- make sure temporary debug edits, generated artifacts, or local-only state files are not being proposed unintentionally
+- update relevant docs when user-visible behavior, verification flow, or release behavior changed
+
+## UI text and i18n
+
+- Any change to user-facing UI text must update both `web/src/i18n/locales/zh-CN.json` and `web/src/i18n/locales/en.json` in the same change.
+- Do not leave one locale ahead of the other.
+
+## Risky actions and permission boundaries
+
+Ask before taking actions that are destructive, hard to reverse, or affect shared state.
+
+Always get explicit user confirmation before:
+- deleting files, branches, worktrees, or generated state the user may still need
+- changing release workflows, packaging outputs, installer behavior, or published artifact expectations
+- changing `.githooks`, network-affecting helper scripts, service install scripts, or machine-level runtime configuration
+- pushing, force-pushing, merging, tagging, or creating releases
+- running commands that change live routing, DNS, TUN state, or local service installation outside the requested verification flow
+
+Never use destructive git shortcuts such as `git reset --hard`, `git checkout --`, or `git clean -f` unless the user explicitly requested that exact action.
+
+## MCP and external-tool governance
+
+- Use repository and local tools first. Only use external web or MCP-backed tools when local files, hooks, scripts, or GitHub metadata are not enough.
+- Treat MCP and web-reader style tools as potentially outbound. Do not send local configs, node data, state snapshots, secrets, or private runtime evidence to third-party tools unless the user explicitly asked for that workflow.
+- For GitHub state related to this repository, prefer the repository's own files and `gh`/GitHub metadata before broader web search.
+
+## Memory and persistence boundaries
+
+- Do not treat runtime state, node-pool contents, subscription payloads, local IPs, tokens, or machine-specific evidence as durable memory.
+- Only retain stable project rules, durable workflow decisions, and long-lived collaboration guidance.
+- Temporary debugging notes belong in the current task, PR, or verification notes, not in durable memory.
+
+## Output style for repository work
+
+When reporting work in this repository:
+- reference code and docs with `file:line` when practical
+- state what changed, what was verified, and any remaining risk
+- do not claim UI or runtime validation that was not actually performed
+- keep summaries concise and operational rather than promotional
+
+## Generated, local-state, and large-file governance
+
+- Do not propose commits that accidentally include local runtime state, generated artifacts, binaries, or debug output unless the change explicitly requires them.
+- Pay extra attention to files such as `control_plane_state.json`, `node_pool_state.json`, `dev-config.current-nodes.json`, `output/`, `backups/`, built binaries, and other local-only evidence.
+- If a large file or generated artifact must change, explain why it belongs in the change and verify that the corresponding source-of-truth docs or workflow expectations stay accurate.
+- Prefer updating source files, scripts, and docs over hand-editing generated outputs.
+
+## Release and packaging sensitivity
+
+- Changes to `.github/workflows/release*.yml`, `.github/workflows/docker.yml`, packaging assets, installer flows, or release-matrix documentation have a higher review bar than normal feature work.
+- When release behavior changes, update the relevant README or release documentation in the same change and call out the artifact impact in verification notes.
+- Do not silently change published artifact expectations, platform coverage, or naming conventions.
+
+## Multi-agent and task coordination
+
+- For multi-step work, keep tasks scoped so one branch/worktree tracks one coherent outcome.
+- If parallel agent work is used, define ownership and avoid overlapping edits to the same flow without an explicit merge plan.
+- Final closeout should name the verification that actually ran and any follow-up still needed.
+
+## Rule maintenance
+
+- Keep this file lean and repository-specific. Add rules here only when they are stable, repeatedly useful, and not already enforced better by code, hooks, or CI.
+- If a rule becomes a repeated mechanical check, prefer moving enforcement into repository scripts, hooks, or CI rather than relying only on prose.
+- If a rule is temporary or issue-specific, keep it in the issue, PR, or implementation plan instead of promoting it here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+This repository uses a hard-gated change workflow for code, docs, WebPanel, and release-related changes.
+
+## Rule entrypoints
+
+Use these files together:
+
+- [`CLAUDE.md`](CLAUDE.md): project-specific working rules for planning, regression checks, risky actions, worktree isolation, repo closeout, runtime safety, and local-state handling
+- [`README.md`](README.md): repository overview, release matrix, build entry points, and contributor workflow summary
+- [`REAL_MACHINE_VERIFICATION.md`](REAL_MACHINE_VERIFICATION.md): required runtime-sensitive verification for TUN, control-plane, routing, and reboot-sensitive changes
+- [`.github/ISSUE_TEMPLATE/change-request.md`](.github/ISSUE_TEMPLATE/change-request.md): issue template for planned changes
+- [`.github/pull_request_template.md`](.github/pull_request_template.md): PR checklist for verification, locale parity, and runtime-sensitive notes
+- [`.githooks/pre-push`](.githooks/pre-push): local push gate
+- [`scripts/check.sh`](scripts/check.sh): unified local verification gate mirrored by CI
+- [`.github/CODEOWNERS`](.github/CODEOWNERS): review ownership for governance-sensitive paths
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md): contributor conduct expectations
+- [`SECURITY.md`](SECURITY.md): private security reporting path
+
+## Required workflow
+
+1. Open or refine an issue for planned work.
+2. Create a branch for that issue.
+3. Make the smallest change that satisfies the requested outcome.
+4. Run `bash scripts/check.sh` before push or PR.
+5. Keep the shared hook path enabled:
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+6. Open a PR using [`.github/pull_request_template.md`](.github/pull_request_template.md).
+7. Include a closing issue reference such as `Closes #123` in the PR body.
+
+## Additional repository requirements
+
+- Any user-facing UI text change must update both `web/src/i18n/locales/zh-CN.json` and `web/src/i18n/locales/en.json` in the same change.
+- Runtime-sensitive changes must include verification notes from [`REAL_MACHINE_VERIFICATION.md`](REAL_MACHINE_VERIFICATION.md).
+- Do not bypass hooks, skip the unified verification gate, or mix unrelated changes in one branch.
+- The unified verification gate rejects local runtime state, backups, debug output, and built binaries in the evaluated change set before push/PR.
+- Do not include local runtime state, debug output, generated artifacts, or built binaries in a PR unless the change explicitly requires them.
+
+## High-risk changes
+
+Changes touching these areas need extra care and usually need an implementation plan before editing:
+
+- TUN, DNS, routing, transparent proxy behavior, startup, clean-state, or runtime helpers
+- node-pool lifecycle, quarantine logic, subscription import, or validation flow
+- release packaging, installer flows, and GitHub Actions release behavior
+- machine-level helper scripts, local service setup, or other runtime-sensitive flows
+
+Use [`CLAUDE.md`](CLAUDE.md) as the canonical rule layer for those cases.

--- a/README.md
+++ b/README.md
@@ -219,13 +219,18 @@ The upstream [README](https://github.com/XTLS/Xray-core#readme) is open, so feel
 
 ## Contributing
 
-[Code of Conduct](https://github.com/XTLS/Xray-core/blob/main/CODE_OF_CONDUCT.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Code Owners](.github/CODEOWNERS)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security Policy](SECURITY.md)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/XTLS/Xray-core)
 
 ### Change Workflow
 
 This repository uses a hard-gated change workflow for local work and PRs.
+
+Project-specific agent rules now live in [`CLAUDE.md`](CLAUDE.md). Use that file as the canonical working rule layer for planning, regression checks, risky actions, worktree isolation, and repo closeout.
 
 1. Open an issue. Use [`.github/ISSUE_TEMPLATE/change-request.md`](.github/ISSUE_TEMPLATE/change-request.md) for planned changes.
 2. Create a branch for that issue.

--- a/scripts/check-local-state-guard.sh
+++ b/scripts/check-local-state-guard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+collect_blocked_paths() {
+  local output
+  if ! output="$($@ 2>/dev/null)"; then
+    return 1
+  fi
+
+  if [[ -z "$output" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+
+    case "$path" in
+      control_plane_state.json|node_pool_state.json|dev-config.current-nodes.json)
+        printf '%s\n' "$path"
+        ;;
+      runtime/*|backups/*|output/*)
+        printf '%s\n' "$path"
+        ;;
+      xray|webpanel.test.exe)
+        printf '%s\n' "$path"
+        ;;
+      *.log|*.bak|*.tmp|debug.*|*/debug.*)
+        printf '%s\n' "$path"
+        ;;
+    esac
+  done <<< "$output"
+}
+
+resolve_ci_base() {
+  local payload_base=""
+
+  if [[ -n "${GITHUB_EVENT_PATH:-}" ]] && [[ -f "${GITHUB_EVENT_PATH}" ]]; then
+    payload_base="$(python3 - <<'PY' "${GITHUB_EVENT_PATH}"
+import json
+import os
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+event_name = os.environ.get('GITHUB_EVENT_NAME', '')
+if event_name == 'pull_request':
+    print(payload.get('pull_request', {}).get('base', {}).get('sha', ''))
+elif event_name == 'push':
+    print(payload.get('before', ''))
+else:
+    print('')
+PY
+)"
+    if [[ -n "$payload_base" ]] && [[ "$payload_base" != "0000000000000000000000000000000000000000" ]] && git rev-parse --verify "${payload_base}^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "$payload_base"
+      return 0
+    fi
+  fi
+
+  if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]] && [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    local remote_ref="origin/${GITHUB_BASE_REF}"
+    if git rev-parse --verify "$remote_ref" >/dev/null 2>&1; then
+      git merge-base HEAD "$remote_ref"
+      return 0
+    fi
+  fi
+
+  if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]] && [[ -n "${GITHUB_EVENT_BEFORE:-}" ]] && [[ "${GITHUB_EVENT_BEFORE}" != "0000000000000000000000000000000000000000" ]]; then
+    if git rev-parse --verify "${GITHUB_EVENT_BEFORE}^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "$GITHUB_EVENT_BEFORE"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+resolve_local_base() {
+  if git rev-parse --verify '@{upstream}' >/dev/null 2>&1; then
+    git merge-base HEAD '@{upstream}'
+    return 0
+  fi
+
+  if git rev-parse --verify 'HEAD~1' >/dev/null 2>&1; then
+    git rev-parse 'HEAD~1'
+    return 0
+  fi
+
+  return 1
+}
+
+base=""
+range_label=""
+blocked_paths=""
+
+staged_paths="$(collect_blocked_paths git diff --cached --name-only || true)"
+unstaged_paths="$(collect_blocked_paths git diff --name-only || true)"
+
+if base="$(resolve_ci_base)"; then
+  range_label="${base}...HEAD + index+worktree"
+  range_paths="$(collect_blocked_paths git diff --name-only "${base}...HEAD")"
+  blocked_paths="$(printf '%s\n%s\n%s\n' "$range_paths" "$staged_paths" "$unstaged_paths" | sed '/^$/d' | sort -u)"
+elif base="$(resolve_local_base)"; then
+  range_label="${base}...HEAD + index+worktree"
+  range_paths="$(collect_blocked_paths git diff --name-only "${base}...HEAD")"
+  blocked_paths="$(printf '%s\n%s\n%s\n' "$range_paths" "$staged_paths" "$unstaged_paths" | sed '/^$/d' | sort -u)"
+else
+  range_label="index+worktree"
+  blocked_paths="$(printf '%s\n%s\n' "$staged_paths" "$unstaged_paths" | sed '/^$/d' | sort -u)"
+fi
+
+if [[ -z "$blocked_paths" ]]; then
+  printf '[local-state-guard] no blocked local-state or build artifacts detected in %s\n' "$range_label"
+  exit 0
+fi
+
+printf '[local-state-guard] remove local runtime state, backups, debug output, or built binaries from the change set before pushing\n' >&2
+printf '[local-state-guard] diff range: %s\n' "$range_label" >&2
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  printf '[local-state-guard] blocked: %s\n' "$path" >&2
+done <<< "$blocked_paths"
+exit 1

--- a/scripts/check-locale-sync.sh
+++ b/scripts/check-locale-sync.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+ZH_FILE="web/src/i18n/locales/zh-CN.json"
+EN_FILE="web/src/i18n/locales/en.json"
+
+collect_locale_changes() {
+  local mode="$1"
+  shift
+
+  local output
+  if ! output="$($@ 2>/dev/null)"; then
+    return 1
+  fi
+
+  if [[ -z "$output" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    case "$line" in
+      "$ZH_FILE"|"$EN_FILE")
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done <<< "$output"
+}
+
+resolve_ci_base() {
+  local payload_base=""
+
+  if [[ -n "${GITHUB_EVENT_PATH:-}" ]] && [[ -f "${GITHUB_EVENT_PATH}" ]]; then
+    payload_base="$(python3 - <<'PY' "${GITHUB_EVENT_PATH}"
+import json
+import os
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+event_name = os.environ.get('GITHUB_EVENT_NAME', '')
+if event_name == 'pull_request':
+    print(payload.get('pull_request', {}).get('base', {}).get('sha', ''))
+elif event_name == 'push':
+    print(payload.get('before', ''))
+else:
+    print('')
+PY
+)"
+    if [[ -n "$payload_base" ]] && [[ "$payload_base" != "0000000000000000000000000000000000000000" ]] && git rev-parse --verify "${payload_base}^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "$payload_base"
+      return 0
+    fi
+  fi
+
+  if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]] && [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    local remote_ref="origin/${GITHUB_BASE_REF}"
+    if git rev-parse --verify "$remote_ref" >/dev/null 2>&1; then
+      git merge-base HEAD "$remote_ref"
+      return 0
+    fi
+  fi
+
+  if [[ "${GITHUB_EVENT_NAME:-}" == "push" ]] && [[ -n "${GITHUB_EVENT_BEFORE:-}" ]] && [[ "${GITHUB_EVENT_BEFORE}" != "0000000000000000000000000000000000000000" ]]; then
+    if git rev-parse --verify "${GITHUB_EVENT_BEFORE}^{commit}" >/dev/null 2>&1; then
+      printf '%s\n' "$GITHUB_EVENT_BEFORE"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+resolve_local_base() {
+  if git rev-parse --verify '@{upstream}' >/dev/null 2>&1; then
+    git merge-base HEAD '@{upstream}'
+    return 0
+  fi
+
+  if git rev-parse --verify 'HEAD~1' >/dev/null 2>&1; then
+    git rev-parse 'HEAD~1'
+    return 0
+  fi
+
+  return 1
+}
+
+base=""
+range_label=""
+changes=""
+
+staged_changes="$(collect_locale_changes staged git diff --cached --name-only || true)"
+unstaged_changes="$(collect_locale_changes unstaged git diff --name-only || true)"
+
+if base="$(resolve_ci_base)"; then
+  range_label="${base}...HEAD + index+worktree"
+  range_changes="$(collect_locale_changes diff-range git diff --name-only "${base}...HEAD")"
+  changes="$(printf '%s\n%s\n%s\n' "$range_changes" "$staged_changes" "$unstaged_changes" | sed '/^$/d' | sort -u)"
+elif base="$(resolve_local_base)"; then
+  range_label="${base}...HEAD + index+worktree"
+  range_changes="$(collect_locale_changes diff-range git diff --name-only "${base}...HEAD")"
+  changes="$(printf '%s\n%s\n%s\n' "$range_changes" "$staged_changes" "$unstaged_changes" | sed '/^$/d' | sort -u)"
+else
+  range_label="index+worktree"
+  changes="$(printf '%s\n%s\n' "$staged_changes" "$unstaged_changes" | sed '/^$/d' | sort -u)"
+fi
+
+zh_changed=0
+en_changed=0
+
+if [[ -n "$changes" ]]; then
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    if [[ "$file" == "$ZH_FILE" ]]; then
+      zh_changed=1
+    fi
+    if [[ "$file" == "$EN_FILE" ]]; then
+      en_changed=1
+    fi
+  done <<< "$changes"
+fi
+
+if [[ "$zh_changed" -eq 0 && "$en_changed" -eq 0 ]]; then
+  printf '[locale-sync] no locale file changes detected in %s\n' "$range_label"
+  exit 0
+fi
+
+if [[ "$zh_changed" -eq 1 && "$en_changed" -eq 1 ]]; then
+  printf '[locale-sync] locale files changed together in %s\n' "$range_label"
+  exit 0
+fi
+
+changed_file="$ZH_FILE"
+missing_file="$EN_FILE"
+if [[ "$en_changed" -eq 1 ]]; then
+  changed_file="$EN_FILE"
+  missing_file="$ZH_FILE"
+fi
+
+printf '[locale-sync] expected both locale files to change together\n' >&2
+printf '[locale-sync] changed: %s\n' "$changed_file" >&2
+printf '[locale-sync] missing: %s\n' "$missing_file" >&2
+printf '[locale-sync] diff range: %s\n' "$range_label" >&2
+exit 1

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -18,11 +18,18 @@ require_cmd go
 require_cmd node
 require_cmd npm
 require_cmd python3
+require_cmd git
 
 cd "$ROOT_DIR"
 
 log "Go webpanel tests"
 go test ./app/webpanel/...
+
+log "Locale sync"
+bash scripts/check-locale-sync.sh
+
+log "Local-state guard"
+bash scripts/check-local-state-guard.sh
 
 if [[ ! -d "$ROOT_DIR/web/node_modules" ]]; then
   log "Install web dependencies"


### PR DESCRIPTION
Closes #90

## Summary
- Add a project-level `CLAUDE.md`, `CONTRIBUTING.md`, and `CODEOWNERS` to codify repository governance rules.
- Add locale-sync and local-state guard scripts to the unified `scripts/check.sh` gate.
- Strengthen PR/CI workflow guardrails for locale parity, runtime-sensitive verification, and reliable diff-base checks.

## Test plan
- [x] `bash scripts/check.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)