### PR TITLE
fix(installer): normalize TUN DNS for sudoers

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -28,6 +28,9 @@ go test ./app/webpanel/...
 log "Locale sync"
 bash scripts/check-locale-sync.sh
 
+log "TUN installer normalization"
+bash scripts/test-webpanel-tun-installer-normalization.sh
+
 log "Local-state guard"
 bash scripts/check-local-state-guard.sh
 

--- a/scripts/install-webpanel-tun-sudoers.sh
+++ b/scripts/install-webpanel-tun-sudoers.sh
@@ -85,23 +85,7 @@ install -o root -g root -m 0755 "$XRAY_SRC" "$XRAY_DST"
 
 config_owner="$(stat -c '%u:%g' "$CONFIG_PATH")"
 
-python3 - "$CONFIG_PATH" "$HELPER_DST" "$XRAY_DST" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-config_path = Path(sys.argv[1])
-helper_dst = sys.argv[2]
-xray_dst = sys.argv[3]
-
-data = json.loads(config_path.read_text(encoding="utf-8"))
-webpanel = data.setdefault("webpanel", {})
-tun = webpanel.setdefault("tun", {})
-tun["helperPath"] = helper_dst
-tun["binaryPath"] = xray_dst
-tun["useSudo"] = True
-config_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-PY
+python3 "$SCRIPT_DIR/normalize-webpanel-tun-config.py" "$CONFIG_PATH" "$HELPER_DST" "$XRAY_DST"
 
 chown "$config_owner" "$CONFIG_PATH"
 

--- a/scripts/normalize-webpanel-tun-config.py
+++ b/scripts/normalize-webpanel-tun-config.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Normalize WebPanel TUN installer config fields.
+
+The WebPanel runtime normalizes remote DNS entries before building the TUN
+helper command. The sudoers installer must write the same exact arguments, or
+`sudo -n -l` readiness checks will reject otherwise valid entries.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import sys
+from pathlib import Path
+
+
+KNOWN_DOH = {
+    "1.1.1.1": "https://cloudflare-dns.com/dns-query",
+    "1.0.0.1": "https://cloudflare-dns.com/dns-query",
+    "8.8.8.8": "https://dns.google/dns-query",
+    "8.8.4.4": "https://dns.google/dns-query",
+    "9.9.9.9": "https://dns.quad9.net/dns-query",
+    "149.112.112.112": "https://dns.quad9.net/dns-query",
+    "223.5.5.5": "https://dns.alidns.com/dns-query",
+    "223.6.6.6": "https://dns.alidns.com/dns-query",
+    "119.29.29.29": "https://doh.pub/dns-query",
+}
+
+PASSTHROUGH_PREFIXES = ("https://", "https+local://", "quic+local://")
+STRIP_PREFIXES = ("tcp://", "tcp+local://", "udp://", "udp+local://")
+
+
+def normalize_resolver_host(value: str) -> str:
+    host = value.strip()
+    if host.startswith("//"):
+        host = host[2:]
+
+    for separator in ("/", "?", "#"):
+        if separator in host:
+            host = host.split(separator, 1)[0]
+
+    if host.startswith("["):
+        end = host.find("]")
+        if end >= 0:
+            bracketed_host = host[1:end]
+            remainder = host[end + 1 :]
+            if not remainder or remainder.startswith(":"):
+                host = bracketed_host
+    elif host.count(":") == 1:
+        split_host, port = host.rsplit(":", 1)
+        if split_host and port.isdigit():
+            host = split_host
+
+    return host.strip("[]")
+
+
+def normalize_resolver(value: object) -> str:
+    trimmed = str(value or "").strip()
+    if not trimmed:
+        return ""
+
+    lower = trimmed.lower()
+    if lower.startswith(PASSTHROUGH_PREFIXES):
+        return trimmed
+
+    for prefix in STRIP_PREFIXES:
+        if lower.startswith(prefix):
+            trimmed = trimmed[len(prefix) :]
+            break
+    else:
+        if "://" in lower:
+            trimmed = trimmed.split("://", 1)[1]
+
+    host = normalize_resolver_host(trimmed)
+    if not host:
+        return ""
+
+    if host in KNOWN_DOH:
+        return KNOWN_DOH[host]
+
+    try:
+        parsed_ip = ipaddress.ip_address(host)
+    except ValueError:
+        parsed_ip = None
+    if parsed_ip and parsed_ip.version == 6:
+        return f"https://[{parsed_ip.compressed}]/dns-query"
+
+    return f"https://{host}/dns-query"
+
+
+def normalize_remote_dns(values: list[object]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        next_value = normalize_resolver(value)
+        if not next_value or next_value in seen:
+            continue
+        normalized.append(next_value)
+        seen.add(next_value)
+    return normalized
+
+
+def update_config(config_path: Path, helper_dst: str, xray_dst: str) -> None:
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    webpanel = data.setdefault("webpanel", {})
+    tun = webpanel.setdefault("tun", {})
+    tun["helperPath"] = helper_dst
+    tun["binaryPath"] = xray_dst
+    tun["useSudo"] = True
+
+    remote_dns = normalize_remote_dns(
+        tun.get("remoteDns")
+        or [
+            "https://cloudflare-dns.com/dns-query",
+            "https://dns.google/dns-query",
+        ]
+    )
+    if remote_dns:
+        tun["remoteDns"] = remote_dns
+
+    config_path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(
+            "usage: normalize-webpanel-tun-config.py CONFIG_PATH HELPER_DST XRAY_DST",
+            file=sys.stderr,
+        )
+        return 2
+
+    update_config(Path(argv[1]), argv[2], argv[3])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/test-webpanel-tun-installer-normalization.sh
+++ b/scripts/test-webpanel-tun-installer-normalization.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CONFIG_PATH="$TMP_DIR/config.json"
+cat >"$CONFIG_PATH" <<'JSON'
+{
+  "webpanel": {
+    "tun": {
+      "runtimeConfigPath": "/tmp/xray-runtime/tun/config.json",
+      "stateDir": "/tmp/xray-runtime/tun",
+      "interfaceName": "xray0",
+      "remoteDns": [
+        "1.1.1.1",
+        "8.8.8.8:53",
+        "udp://9.9.9.9",
+        "https://dns.google/dns-query",
+        "tcp+local://119.29.29.29",
+        "[2606:4700:4700::1111]:53"
+      ]
+    }
+  }
+}
+JSON
+
+python3 "$ROOT_DIR/scripts/normalize-webpanel-tun-config.py" \
+  "$CONFIG_PATH" \
+  "/usr/local/libexec/xray-webpanel-tun-helper" \
+  "/usr/local/bin/xray-webpanel-xray"
+
+python3 - "$CONFIG_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+tun = data["webpanel"]["tun"]
+
+expected_remote_dns = [
+    "https://cloudflare-dns.com/dns-query",
+    "https://dns.google/dns-query",
+    "https://dns.quad9.net/dns-query",
+    "https://doh.pub/dns-query",
+    "https://[2606:4700:4700::1111]/dns-query",
+]
+
+assert tun["helperPath"] == "/usr/local/libexec/xray-webpanel-tun-helper"
+assert tun["binaryPath"] == "/usr/local/bin/xray-webpanel-xray"
+assert tun["useSudo"] is True
+assert tun["remoteDns"] == expected_remote_dns, tun["remoteDns"]
+PY


### PR DESCRIPTION
Closes #105

## Summary

Normalize WebPanel TUN `remoteDns` values during sudoers installation so exact-argument NOPASSWD entries match the runtime DoH arguments used by the WebPanel TUN helper.

## Linked Issue

Closes #105

## Scope

- Added a shared rootless config normalizer for TUN installer fields.
- Updated the sudoers installer to use the same normalized encrypted DNS values that runtime commands use.
- Added a rootless regression test and wired it into `scripts/check.sh`.
- Did not change live TUN start/stop behavior or routing policy.

## Verification

- [x] `bash -n scripts/install-webpanel-tun-sudoers.sh`
- [x] `bash scripts/test-webpanel-tun-installer-normalization.sh`
- [x] `bash scripts/check.sh`
- [ ] I tested the affected user flow locally
- [x] UI text changes updated both `web/src/i18n/locales/zh-CN.json` and `web/src/i18n/locales/en.json`, or this PR does not change UI text
- [x] Runtime-sensitive changes include verification notes from `REAL_MACHINE_VERIFICATION.md`, or this PR is not runtime-sensitive

Affected local user flow still requires rerunning the installer with sudo from this fixed branch, then restarting the user service. Current preflight remains blocked until that machine-level reinstall is done with this fixed script.

## Risks

Main regression surface is parity with `normalizeTunRemoteDNS` in the Go runtime. The added test covers bare IP, host:port, UDP/TCP schemes, duplicate DoH entries, Tencent DNS, and IPv6 host:port normalization.