### PR TITLE
fix(installer): escape TUN sudoers URL arguments

### DIFF
--- a/app/webpanel/tun_manager.go
+++ b/app/webpanel/tun_manager.go
@@ -3190,8 +3190,7 @@ func sudoListingHasNoPasswordCommand(listing, expectedCommand string) bool {
 			if passwdIndex := strings.Index(section, "PASSWD:"); passwdIndex >= 0 {
 				section = section[:passwdIndex]
 			}
-			for _, command := range strings.Split(section, ",") {
-				command = strings.TrimSpace(command)
+			for _, command := range splitSudoCommandSpecs(section) {
 				if command == "ALL" || command == expectedCommand {
 					return true
 				}
@@ -3200,6 +3199,41 @@ func sudoListingHasNoPasswordCommand(listing, expectedCommand string) bool {
 	}
 
 	return false
+}
+
+func splitSudoCommandSpecs(section string) []string {
+	commands := make([]string, 0, 1)
+	var current strings.Builder
+	escaped := false
+
+	for _, char := range section {
+		if escaped {
+			current.WriteRune(char)
+			escaped = false
+			continue
+		}
+
+		switch char {
+		case '\\':
+			escaped = true
+		case ',':
+			if token := strings.TrimSpace(current.String()); token != "" {
+				commands = append(commands, token)
+			}
+			current.Reset()
+		default:
+			current.WriteRune(char)
+		}
+	}
+
+	if escaped {
+		current.WriteRune('\\')
+	}
+	if token := strings.TrimSpace(current.String()); token != "" {
+		commands = append(commands, token)
+	}
+
+	return commands
 }
 
 func filesMatch(leftPath, rightPath string) (bool, error) {

--- a/app/webpanel/tun_manager_test.go
+++ b/app/webpanel/tun_manager_test.go
@@ -231,6 +231,27 @@ func TestSudoListingAllowsTunActionsWithoutPasswordRejectsStaleBinaryPath(t *tes
 	}
 }
 
+func TestSudoListingAllowsTunActionsWithoutPasswordHandlesEscapedSudoersOutput(t *testing.T) {
+	t.Parallel()
+
+	settings := &TunFeatureSettings{
+		HelperPath:        "/usr/local/libexec/xray-webpanel-tun-helper",
+		BinaryPath:        "/repo/xray",
+		RuntimeConfigPath: "/repo/runtime/tun/config.json",
+		StateDir:          "/repo/runtime/tun",
+		InterfaceName:     "xray0",
+		RemoteDNS:         []string{"https://cloudflare-dns.com/dns-query", "https://dns.google/dns-query", "https://dns.quad9.net/dns-query"},
+	}
+
+	listing := `User leo may run the following commands:
+    (root) NOPASSWD: /usr/local/libexec/xray-webpanel-tun-helper start /repo/xray /repo/runtime/tun/config.json /repo/runtime/tun xray0 https\://cloudflare-dns.com/dns-query https\://dns.google/dns-query https\://dns.quad9.net/dns-query
+    (root) NOPASSWD: /usr/local/libexec/xray-webpanel-tun-helper stop /repo/xray /repo/runtime/tun/config.json /repo/runtime/tun xray0 https\://cloudflare-dns.com/dns-query https\://dns.google/dns-query https\://dns.quad9.net/dns-query`
+
+	if !sudoListingAllowsTunActionsWithoutPassword(settings, listing) {
+		t.Fatal("expected escaped sudoers listing output to be accepted")
+	}
+}
+
 func TestTunManagerResolveRepoScriptPathPrefersRunningBinaryDirectory(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/install-webpanel-tun-sudoers.sh
+++ b/scripts/install-webpanel-tun-sudoers.sh
@@ -30,6 +30,15 @@ HELPER_DST="/usr/local/libexec/xray-webpanel-tun-helper"
 XRAY_SRC="$REPO_ROOT/xray"
 XRAY_DST="/usr/local/bin/xray-webpanel-xray"
 SUDOERS_FILE="/etc/sudoers.d/xray-webpanel-tun"
+TMP_SUDOERS_FILE=""
+
+cleanup_temp_sudoers() {
+  if [[ -n "$TMP_SUDOERS_FILE" && -f "$TMP_SUDOERS_FILE" ]]; then
+    rm -f "$TMP_SUDOERS_FILE"
+  fi
+}
+
+trap cleanup_temp_sudoers EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -142,15 +151,21 @@ for dns in "${REMOTE_DNS[@]}"; do
   cmd_suffix_toggle+=" $dns"
 done
 
-cat >"$SUDOERS_FILE" <<EOF
-# Managed by install-webpanel-tun-sudoers.sh
-$TARGET_USER ALL=(root) NOPASSWD: $HELPER_DST $cmd_suffix_start
-$TARGET_USER ALL=(root) NOPASSWD: $HELPER_DST $cmd_suffix_stop
-$TARGET_USER ALL=(root) NOPASSWD: $HELPER_DST $cmd_suffix_toggle
-EOF
+TMP_SUDOERS_FILE="$(mktemp)"
+python3 "$SCRIPT_DIR/render-webpanel-tun-sudoers.py" \
+  "$TARGET_USER" \
+  "$HELPER_DST" \
+  "$XRAY_DST" \
+  "$RUNTIME_CONFIG_PATH" \
+  "$STATE_DIR" \
+  "$INTERFACE_NAME" \
+  "${REMOTE_DNS[@]}" >"$TMP_SUDOERS_FILE"
 
-chmod 0440 "$SUDOERS_FILE"
-visudo -cf "$SUDOERS_FILE" >/dev/null
+chmod 0440 "$TMP_SUDOERS_FILE"
+visudo -cf "$TMP_SUDOERS_FILE" >/dev/null
+install -o root -g root -m 0440 "$TMP_SUDOERS_FILE" "$SUDOERS_FILE"
+cleanup_temp_sudoers
+TMP_SUDOERS_FILE=""
 
 cat <<EOF
 Installed helper: $HELPER_DST

--- a/scripts/render-webpanel-tun-sudoers.py
+++ b/scripts/render-webpanel-tun-sudoers.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Render escaped sudoers entries for WebPanel TUN helper actions."""
+
+from __future__ import annotations
+
+import sys
+
+
+def escape_sudoers_token(value: str) -> str:
+    escaped: list[str] = []
+    for char in value:
+        if char in {"\\", ",", ":", "="}:
+            escaped.append("\\")
+        escaped.append(char)
+    return "".join(escaped)
+
+
+def render_line(
+    target_user: str,
+    helper_dst: str,
+    action: str,
+    xray_dst: str,
+    runtime_config_path: str,
+    state_dir: str,
+    interface_name: str,
+    remote_dns: list[str],
+) -> str:
+    args = [
+        helper_dst,
+        action,
+        xray_dst,
+        runtime_config_path,
+        state_dir,
+        interface_name,
+        *remote_dns,
+    ]
+    escaped_args = " ".join(escape_sudoers_token(value) for value in args)
+    return f"{target_user} ALL=(root) NOPASSWD: {escaped_args}"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 8:
+        print(
+            "usage: render-webpanel-tun-sudoers.py TARGET_USER HELPER_DST XRAY_DST "
+            "RUNTIME_CONFIG_PATH STATE_DIR INTERFACE_NAME REMOTE_DNS...",
+            file=sys.stderr,
+        )
+        return 2
+
+    target_user = argv[1]
+    helper_dst = argv[2]
+    xray_dst = argv[3]
+    runtime_config_path = argv[4]
+    state_dir = argv[5]
+    interface_name = argv[6]
+    remote_dns = argv[7:]
+
+    lines = ["# Managed by install-webpanel-tun-sudoers.sh"]
+    for action in ("start", "stop", "toggle"):
+        lines.append(
+            render_line(
+                target_user,
+                helper_dst,
+                action,
+                xray_dst,
+                runtime_config_path,
+                state_dir,
+                interface_name,
+                remote_dns,
+            )
+        )
+    sys.stdout.write("\n".join(lines) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/test-webpanel-tun-installer-normalization.sh
+++ b/scripts/test-webpanel-tun-installer-normalization.sh
@@ -31,6 +31,24 @@ python3 "$ROOT_DIR/scripts/normalize-webpanel-tun-config.py" \
   "/usr/local/libexec/xray-webpanel-tun-helper" \
   "/usr/local/bin/xray-webpanel-xray"
 
+SUDOERS_PATH="$TMP_DIR/xray-webpanel-tun"
+python3 "$ROOT_DIR/scripts/render-webpanel-tun-sudoers.py" \
+  "leo-cy" \
+  "/usr/local/libexec/xray-webpanel-tun-helper" \
+  "/usr/local/bin/xray-webpanel-xray" \
+  "/tmp/xray-runtime/tun/config.json" \
+  "/tmp/xray-runtime/tun" \
+  "xray0" \
+  "https://cloudflare-dns.com/dns-query" \
+  "https://dns.google/dns-query" \
+  "https://dns.quad9.net/dns-query" \
+  "https://doh.pub/dns-query" \
+  "https://[2606:4700:4700::1111]/dns-query" >"$SUDOERS_PATH"
+
+visudo -cf "$SUDOERS_PATH" >/dev/null
+grep -Fq 'https\://cloudflare-dns.com/dns-query' "$SUDOERS_PATH"
+grep -Fq 'https\://[2606\:4700\:4700\:\:1111]/dns-query' "$SUDOERS_PATH"
+
 python3 - "$CONFIG_PATH" <<'PY'
 import json
 import sys


### PR DESCRIPTION
Closes #107

## Summary

Escape sudoers command arguments when rendering WebPanel TUN helper rules so normalized DoH URLs such as `https://cloudflare-dns.com/dns-query` produce valid sudoers syntax. The installer now validates a temporary sudoers file before replacing the final include.

## Linked Issue

Closes #107

## Scope

- Added a rootless sudoers renderer that escapes `\`, `,`, `:`, and `=` in command tokens.
- Updated the installer to run `visudo -cf` on a temporary file before installing `/etc/sudoers.d/xray-webpanel-tun`.
- Updated sudo readiness parsing to match escaped `sudo -l` output.
- Extended the TUN installer regression test to render DoH URL rules and validate them with `visudo -cf`.
- Did not change TUN routing, DNS policy, or helper start/stop semantics.

## Verification

- [x] `bash -n scripts/install-webpanel-tun-sudoers.sh`
- [x] `bash scripts/test-webpanel-tun-installer-normalization.sh`
- [x] `go test ./app/webpanel/...`
- [x] `bash scripts/check.sh`
- [ ] I tested the affected user flow locally
- [x] UI text changes updated both `web/src/i18n/locales/zh-CN.json` and `web/src/i18n/locales/en.json`, or this PR does not change UI text
- [x] Runtime-sensitive changes include verification notes from `REAL_MACHINE_VERIFICATION.md`, or this PR is not runtime-sensitive

Machine-level validation still requires rerunning the installer with sudo after this PR lands because the current `/etc/sudoers.d/xray-webpanel-tun` was created before this escaping fix.

## Risks

Main risk is sudoers syntax parity. The regression test now runs the rendered file through `visudo -cf`, and the Go parser test covers escaped `sudo -l` output.