### PR TITLE
chore(release): v2026.4.22

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xray-webpanel",
-  "version": "2026.4.21",
+  "version": "2026.4.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xray-webpanel",
-      "version": "2026.4.21",
+      "version": "2026.4.22",
       "dependencies": {
         "axios": "^1.7.0",
         "echarts": "^5.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-webpanel",
-  "version": "2026.4.21",
+  "version": "2026.4.22",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump WebPanel package version to 2026.4.22
- prepare GitHub Release v2026.4.22 for the strict TUN privacy fixes merged in #110

## Verification
- bash scripts/check.sh
- pre-push hook ran bash scripts/check.sh

Closes #111